### PR TITLE
Add documentation GitHub action

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,26 @@
+name: Documentation
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate Documentation
+        uses: SwiftDocOrg/swift-doc@master
+        with:
+          format: html
+          module-name: "W3C Trace Context"
+          output: Documentation
+      - name: Update Permissions
+        run: 'sudo chown --recursive $USER Documentation'
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: Documentation


### PR DESCRIPTION
Adds a GitHub action to generate documentation via `swift-doc`, deployed on GitHub Pages.