### PR TITLE
Generate random trace parent

### DIFF
--- a/Sources/W3CTraceContext/TraceParent.swift
+++ b/Sources/W3CTraceContext/TraceParent.swift
@@ -106,3 +106,46 @@ extension TraceParent: CustomStringConvertible {
         self.rawValue
     }
 }
+
+extension TraceParent {
+    /// Returns a random `TraceParent`, using the given generator as a source for randomness.
+    /// - Parameter generator: The random number generator used as a source for generating the different values.
+    /// - Note: `traceFlags` will be set to 0.
+    /// - Returns: A `TraceParent` with random `traceID` & `parentID`.
+    public static func random<G: RandomNumberGenerator>(using generator: inout G) -> TraceParent {
+        let traceID = Self.randomTraceID(using: &generator)
+        let parentID = Self.randomParentID(using: &generator)
+        return .init(traceID: traceID, parentID: parentID, traceFlags: UInt64(0).paddedHexString(radix: 2))
+    }
+
+    /// Returns a random `TraceParent` using the system random number generator.
+    /// - Note: `traceFlags` will be set to 0.
+    /// - Returns: A `TraceParent` with random `traceID` & `parentID`.
+    public static func random() -> TraceParent {
+        var g = SystemRandomNumberGenerator()
+        return .random(using: &g)
+    }
+
+    static func randomTraceID<G: RandomNumberGenerator>(using generator: inout G) -> String {
+        let traceIDHigh = UInt64
+            .random(in: 1 ... UInt64.max, using: &generator)
+            .paddedHexString(radix: 16)
+        let traceIDLow = UInt64
+            .random(in: 1 ... UInt64.max, using: &generator)
+            .paddedHexString(radix: 16)
+        return traceIDHigh + traceIDLow
+    }
+
+    static func randomParentID<G: RandomNumberGenerator>(using generator: inout G) -> String {
+        UInt64
+            .random(in: 1 ... UInt64.max, using: &generator)
+            .paddedHexString(radix: 16)
+    }
+}
+
+extension UInt64 {
+    func paddedHexString(radix: Int) -> String {
+        let unpadded = String(self, radix: radix, uppercase: false)
+        return String(repeating: "0", count: radix - unpadded.count) + unpadded
+    }
+}

--- a/Sources/W3CTraceContext/TraceState.swift
+++ b/Sources/W3CTraceContext/TraceState.swift
@@ -65,7 +65,6 @@ extension TraceState: RawRepresentable {
                 } else if horizontalSpaces.contains(rest[rest.index(before: rest.endIndex)]) {
                     rest.removeLast()
                 } else {
-                    print(rest)
                     break
                 }
             }

--- a/Tests/W3CTraceContextTests/TraceParentTests.swift
+++ b/Tests/W3CTraceContextTests/TraceParentTests.swift
@@ -150,6 +150,15 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertNotEqual(parent1, parent2)
     }
+
+    // MARK: - Random
+
+    func test_generate_random_traceParent() {
+        let traceParent = TraceParent.random()
+
+        // validate random trace-parent by parsing its raw value
+        XCTAssertNotNil(TraceParent(rawValue: traceParent.rawValue))
+    }
 }
 
 private func XCTAssertUninitializedTraceParent(_ rawValue: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Adds a factory method on `TraceParent` to generate a random trace parent. This sets random values for both `traceID` and `parentID`.