### PR TITLE
Make TraceContext value init public

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the [W3C Trace Context standard (Level 1)](https://www.w3.org/TR/2020/REC-trace-
 Add the following package dependency to your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/slashmo/swift-w3c-trace-context", from: "0.2.0")
+.package(url: "https://github.com/slashmo/swift-w3c-trace-context", from: "0.3.0")
 ```
 
 Then, add the `W3CTraceContext` library as a product dependency to each target you want to use it in:

--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -20,7 +20,12 @@ public struct TraceContext: Equatable {
     /// The `TraceState` containing potentially vendor-specific trace information.
     public let state: TraceState
 
-    init(parent: TraceParent, state: TraceState) {
+    /// Create a `TraceContext` from the given parent and state.
+    ///
+    /// - Parameters:
+    ///   - parent: The `TraceParent` stored in this context.
+    ///   - state: The `TraceState` stored in this context.
+    public init(parent: TraceParent, state: TraceState) {
         self.parent = parent
         self.state = state
     }


### PR DESCRIPTION
Users may want to initialize a `TraceContext` not by parsing raw Strings but by creating initialized values for `TraceParent` & `TraceState` to combine them in a `TraceContext`.