### PR TITLE
Enable mutating sampled flag

### DIFF
--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -30,8 +30,7 @@ public struct TraceContext: Equatable {
         self.state = state
     }
 
-    /// When `true`, the least significant bit (right-most), denotes that the caller may have recorded trace data.
-    /// When `false`, the caller did not record trace data out-of-band.
+    /// Whether the caller may have recorded trace data.
     ///
     /// - SeeAlso: [W3C TraceContext: Sampled flag](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/#sampled-flag)
     public var sampled: Bool {

--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -30,6 +30,23 @@ public struct TraceContext: Equatable {
         self.state = state
     }
 
+    /// When `true`, the least significant bit (right-most), denotes that the caller may have recorded trace data.
+    /// When `false`, the caller did not record trace data out-of-band.
+    ///
+    /// - SeeAlso: [W3C TraceContext: Sampled flag](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/#sampled-flag)
+    public var sampled: Bool {
+        get {
+            self.parent.traceFlags.contains(.sampled)
+        }
+        set {
+            if newValue {
+                self.parent.traceFlags.insert(.sampled)
+            } else {
+                self.parent.traceFlags.remove(.sampled)
+            }
+        }
+    }
+
     /// Create a `TraceContext` by parsing the given header values.
     ///
     /// - Parameters:

--- a/Sources/W3CTraceContext/TraceFlags.swift
+++ b/Sources/W3CTraceContext/TraceFlags.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Represents an 8-bit field that controls tracing flags such as sampling.
 public struct TraceFlags: OptionSet {
     public let rawValue: UInt8
 

--- a/Sources/W3CTraceContext/TraceFlags.swift
+++ b/Sources/W3CTraceContext/TraceFlags.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift W3C Trace Context open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift W3C Trace Context project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct TraceFlags: OptionSet {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    /// [W3C TraceContext: Sampled flag](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/#sampled-flag)
+    public static let sampled = TraceFlags(rawValue: 1 << 0)
+}
+
+extension TraceFlags: CustomStringConvertible {
+    public var description: String {
+        let radix = 2
+        let unpadded = String(self.rawValue, radix: radix, uppercase: false)
+        return String(repeating: "0", count: radix - unpadded.count) + unpadded
+    }
+}

--- a/Tests/W3CTraceContextTests/TraceContextTests.swift
+++ b/Tests/W3CTraceContextTests/TraceContextTests.swift
@@ -30,7 +30,7 @@ final class TraceContextTests: XCTestCase {
                 parent: TraceParent(
                     traceID: "0af7651916cd43dd8448eb211c80319c",
                     parentID: "b7ad6b7169203331",
-                    traceFlags: "01"
+                    traceFlags: .sampled
                 ),
                 state: TraceState([("rojo", "00f067aa0ba902b7")])
             )
@@ -55,7 +55,7 @@ final class TraceContextTests: XCTestCase {
                 parent: TraceParent(
                     traceID: "0af7651916cd43dd8448eb211c80319c",
                     parentID: "b7ad6b7169203331",
-                    traceFlags: "01"
+                    traceFlags: .sampled
                 ),
                 state: TraceState([])
             )
@@ -76,5 +76,18 @@ final class TraceContextTests: XCTestCase {
         let newTraceContext = traceContext.regeneratingParentID()
 
         XCTAssertNotEqual(newTraceContext.parent.parentID, traceContext.parent.parentID)
+    }
+
+    func test_update_sampled_flag_sets_parent_trace_flags() {
+        var traceContext = TraceContext(parent: .random(), state: .none)
+        XCTAssertFalse(traceContext.sampled)
+
+        traceContext.sampled = true
+        XCTAssert(traceContext.sampled)
+        XCTAssert(traceContext.parent.traceFlags.contains(.sampled))
+
+        traceContext.sampled = false
+        XCTAssertFalse(traceContext.sampled)
+        XCTAssertFalse(traceContext.parent.traceFlags.contains(.sampled))
     }
 }

--- a/Tests/W3CTraceContextTests/TraceParentTests.swift
+++ b/Tests/W3CTraceContextTests/TraceParentTests.swift
@@ -21,7 +21,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
         let traceParent = TraceParent(
             traceID: "0af7651916cd43dd8448eb211c80319c",
             parentID: "b7ad6b7169203331",
-            traceFlags: "01"
+            traceFlags: .sampled
         )
 
         XCTAssertEqual(traceParent.rawValue, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
@@ -38,10 +38,21 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertEqual(
             traceParent,
-            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: "01")
+            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: .sampled)
         )
+    }
 
-        XCTAssert(traceParent.sampled)
+    func testDecodeValidTraceParentStringWithUnsupportedTraceFlags() {
+        let rawValue = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-11"
+        guard let traceParent = TraceParent(rawValue: rawValue) else {
+            XCTFail("Could not decode valid trace parent")
+            return
+        }
+
+        XCTAssertEqual(
+            traceParent,
+            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: [])
+        )
     }
 
     func testDecodeValidTraceParentStringWithoutSampledFlag() {
@@ -53,10 +64,10 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertEqual(
             traceParent,
-            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: "00")
+            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: [])
         )
 
-        XCTAssertFalse(traceParent.sampled)
+        XCTAssertFalse(traceParent.traceFlags.contains(.sampled))
     }
 
     func testDecodeFailsWithTooLongRawValue() {


### PR DESCRIPTION
As part of an effort to enabling mutation of the sampled flag, I refactored `traceParent.traceFlags` to use an `OptionSet`. Because the W3C Trace Context spec only supports `TraceFlags.sampled` at this point, `parent.traceFlags` cannot be mutated directly. Instead, `TraceContext` itself now has a get/set `sampled` property that internally retrieves from/writes to `parent.traceFlags`. 

When parsing `TraceParent` from its String representation, any `traceFlags` value higher than `01` will be ignored and `traceFlags` default to `00` (not sampled), as required in the spec:

> The behavior of other flags, such as (00000100) is not defined and is reserved for future use. Vendors MUST set those to zero.