### PR TITLE
Hold trace-id in TraceID struct

### DIFF
--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift W3C Trace Context open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift W3C Trace Context project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A unique identifier of a distributed trace through a system.
+public struct TraceID {
+    /// The high (left) part of this trace id.
+    public let high: UInt64
+
+    /// The low (right) part of this trace id.
+    public let low: UInt64
+
+    /// Initialize a `TraceID` with the given high and low parts.
+    ///
+    /// - Parameters:
+    ///   - high: The high part of the trace id
+    ///   - low: The low part of the trace id
+    public init(high: UInt64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+
+    /// Initialize a `TraceID` from the given hex string.
+    ///
+    /// - Parameter hexString: The hex string representation of the trace id to be initialized.
+    public init?<Hex: StringProtocol>(hexString: Hex) {
+        guard hexString.count == 32, hexString != Substring(repeating: "0", count: 32) else { return nil }
+        let highStartIndex = hexString.startIndex
+        let lowStartIndex = hexString.index(highStartIndex, offsetBy: 16)
+        guard let high = UInt64(hexString[highStartIndex ..< lowStartIndex], radix: 16) else { return nil }
+        guard let low = UInt64(hexString[lowStartIndex ..< hexString.endIndex], radix: 16) else { return nil }
+        self.init(high: high, low: low)
+    }
+
+    /// Generate a random `TraceID`.
+    ///
+    /// - Returns: A random `TraceID`.
+    public static func random() -> TraceID {
+        var generator = SystemRandomNumberGenerator()
+        return self.random(using: &generator)
+    }
+
+    /// Generate a random `TraceID` using the given `RandomNumberGenerator`.
+    ///
+    /// - Parameter generator: The generator used to produce the `high` and `low` part.
+    /// - Returns: A random `TraceID`.
+    public static func random<G: RandomNumberGenerator>(using generator: inout G) -> TraceID {
+        TraceID(
+            high: .random(in: 1 ... .max, using: &generator),
+            low: .random(in: 1 ... .max, using: &generator)
+        )
+    }
+}
+
+extension TraceID: Equatable {
+    public static func == (lhs: TraceID, rhs: TraceID) -> Bool {
+        lhs.high == rhs.high && lhs.low == rhs.low
+    }
+}
+
+extension TraceID: Comparable {
+    public static func < (lhs: TraceID, rhs: TraceID) -> Bool {
+        (lhs.high < rhs.high) || (lhs.high == rhs.high && lhs.low < rhs.low)
+    }
+}
+
+extension TraceID: CustomStringConvertible {
+    public var description: String {
+        let highHex = self.high.paddedHexString(radix: 16)
+        let lowHex = self.low.paddedHexString(radix: 16)
+        return "\(highHex)\(lowHex)"
+    }
+}

--- a/Tests/W3CTraceContextTests/QueueBasedRandomNumberGenerator.swift
+++ b/Tests/W3CTraceContextTests/QueueBasedRandomNumberGenerator.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift W3C Trace Context open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift W3C Trace Context project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+struct QueueBasedRandomNumberGenerator: RandomNumberGenerator {
+    var queue: [UInt64]
+    private let file: StaticString
+    private let line: UInt
+
+    init(queue: [UInt64], file: StaticString = #file, line: UInt = #line) {
+        self.queue = queue
+        self.file = file
+        self.line = line
+    }
+
+    mutating func next() -> UInt64 {
+        guard !self.queue.isEmpty else {
+            XCTFail("Requested more random numbers than contained in queue", file: self.file, line: self.line)
+            preconditionFailure()
+        }
+        return self.queue.removeFirst()
+    }
+}

--- a/Tests/W3CTraceContextTests/TestRandomNumberGenerator.swift
+++ b/Tests/W3CTraceContextTests/TestRandomNumberGenerator.swift
@@ -13,7 +13,7 @@
 
 import XCTest
 
-struct QueueBasedRandomNumberGenerator: RandomNumberGenerator {
+struct TestRandomNumberGenerator: RandomNumberGenerator {
     var queue: [UInt64]
     private let file: StaticString
     private let line: UInt

--- a/Tests/W3CTraceContextTests/TraceContextTests.swift
+++ b/Tests/W3CTraceContextTests/TraceContextTests.swift
@@ -28,7 +28,7 @@ final class TraceContextTests: XCTestCase {
             traceContext,
             TraceContext(
                 parent: TraceParent(
-                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
                     parentID: "b7ad6b7169203331",
                     traceFlags: .sampled
                 ),
@@ -53,7 +53,7 @@ final class TraceContextTests: XCTestCase {
             traceContext,
             TraceContext(
                 parent: TraceParent(
-                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
                     parentID: "b7ad6b7169203331",
                     traceFlags: .sampled
                 ),

--- a/Tests/W3CTraceContextTests/TraceContextTests.swift
+++ b/Tests/W3CTraceContextTests/TraceContextTests.swift
@@ -28,7 +28,7 @@ final class TraceContextTests: XCTestCase {
             traceContext,
             TraceContext(
                 parent: TraceParent(
-                    traceID: "0af7651916cd43dd8448eb211c80319c",
+                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
                     parentID: "b7ad6b7169203331",
                     traceFlags: .sampled
                 ),
@@ -53,7 +53,7 @@ final class TraceContextTests: XCTestCase {
             traceContext,
             TraceContext(
                 parent: TraceParent(
-                    traceID: "0af7651916cd43dd8448eb211c80319c",
+                    traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
                     parentID: "b7ad6b7169203331",
                     traceFlags: .sampled
                 ),

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift W3C Trace Context open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift W3C Trace Context project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import W3CTraceContext
+import XCTest
+
+final class TraceIDTests: XCTestCase {
+    // MARK: - Decoding
+
+    func test_decodingFromHexString_succeeds() throws {
+        let high: UInt64 = 9_532_127_138_774_266_268
+        let low: UInt64 = 790_211_418_057_950_173
+        let hexString = high.paddedHexString(radix: 16) + low.paddedHexString(radix: 16)
+
+        let traceID = try XCTUnwrap(TraceID(hexString: hexString))
+        XCTAssertEqual(traceID.high, high)
+        XCTAssertEqual(traceID.low, low)
+    }
+
+    func test_decodingFromHexString_fails_invalidHex() {
+        XCTAssertNil(TraceID(hexString: "THIRTY_TWO_INVALID_HEXCHARACTERS"))
+    }
+
+    func test_decodingFromHexString_fails_invalidHighHex() {
+        XCTAssertNil(TraceID(hexString: "INVALIDHIGHERHEXbd75781e8c42f2c1"))
+    }
+
+    func test_decodingFromHexString_fails_invalidLowHex() {
+        XCTAssertNil(TraceID(hexString: "bd75781e8c42f2c1_INVALIDLOWERHEX"))
+    }
+
+    func test_decodingFromHexString_fails_tooShort() {
+        XCTAssertNil(TraceID(hexString: "tooshort"))
+    }
+
+    func test_decodingFromHexString_fails_allZeros() {
+        XCTAssertNil(TraceID(hexString: String(repeating: "0", count: 16)))
+    }
+
+    // MARK: - Encoding
+
+    func test_encodingToHexString_succeeds() {
+        let traceID = TraceID(high: .max, low: .max)
+
+        XCTAssertEqual(String(describing: traceID), "ffffffffffffffffffffffffffffffff")
+    }
+
+    func test_encodingToHexString_padsLeadingZeros() {
+        let traceID = TraceID(high: 256, low: 256)
+
+        XCTAssertEqual(String(describing: traceID), "00000000000001000000000000000100")
+    }
+
+    // MARK: - Equality
+
+    func test_equatingTraceIDs_succeeds() {
+        let traceID = TraceID(high: 1, low: 1)
+
+        XCTAssertEqual(traceID, TraceID(high: 1, low: 1))
+        XCTAssertNotEqual(traceID, TraceID(high: 2, low: 1))
+        XCTAssertNotEqual(traceID, TraceID(high: 1, low: 2))
+        XCTAssertNotEqual(traceID, TraceID(high: 2, low: 2))
+    }
+
+    // MARK: - Comparison
+
+    func test_comparingTraceIDs_succeeds() {
+        XCTAssertGreaterThan(TraceID(high: 3, low: 3), TraceID(high: 2, low: 2))
+        XCTAssertGreaterThan(TraceID(high: 2, low: 3), TraceID(high: 2, low: 2))
+        XCTAssertGreaterThan(TraceID(high: 2, low: 2), TraceID(high: 1, low: 1))
+        XCTAssertGreaterThan(TraceID(high: 2, low: 2), TraceID(high: 2, low: 1))
+    }
+
+    // MARK: - Randomness
+
+    func test_generatingRandomTraceID_succeeds_usingSystemNumberGenerator() {
+        let traceID = TraceID.random()
+
+        // must always be greater than 0 to be valid
+        XCTAssertGreaterThan(traceID.high, 0)
+        XCTAssertGreaterThan(traceID.low, 0)
+    }
+
+    func test_generatingRandomTraceID_succeeds_usingTestNumberGenerator() {
+        var generator = QueueBasedRandomNumberGenerator(queue: [1, 2])
+
+        let traceID = TraceID.random(using: &generator)
+        XCTAssertEqual(traceID, TraceID(high: 1, low: 2))
+    }
+}

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -92,7 +92,7 @@ final class TraceIDTests: XCTestCase {
     }
 
     func test_generatingRandomTraceID_succeeds_usingTestNumberGenerator() {
-        var generator = QueueBasedRandomNumberGenerator(queue: [1, 2])
+        var generator = TestRandomNumberGenerator(queue: [1, 2])
 
         let traceID = TraceID.random(using: &generator)
         XCTAssertEqual(traceID, TraceID(high: 1, low: 2))

--- a/Tests/W3CTraceContextTests/TraceParentTests.swift
+++ b/Tests/W3CTraceContextTests/TraceParentTests.swift
@@ -19,7 +19,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
     func testEncodesToValidRawValue() {
         let traceParent = TraceParent(
-            traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+            traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
             parentID: "b7ad6b7169203331",
             traceFlags: .sampled
         )
@@ -39,7 +39,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
         XCTAssertEqual(
             traceParent,
             TraceParent(
-                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
                 parentID: "b7ad6b7169203331",
                 traceFlags: .sampled
             )
@@ -56,7 +56,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
         XCTAssertEqual(
             traceParent,
             TraceParent(
-                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
                 parentID: "b7ad6b7169203331",
                 traceFlags: []
             )
@@ -73,7 +73,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
         XCTAssertEqual(
             traceParent,
             TraceParent(
-                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!, // !-safe, we know this is a valid traceID
                 parentID: "b7ad6b7169203331",
                 traceFlags: []
             )

--- a/Tests/W3CTraceContextTests/TraceParentTests.swift
+++ b/Tests/W3CTraceContextTests/TraceParentTests.swift
@@ -19,7 +19,7 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
     func testEncodesToValidRawValue() {
         let traceParent = TraceParent(
-            traceID: "0af7651916cd43dd8448eb211c80319c",
+            traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
             parentID: "b7ad6b7169203331",
             traceFlags: .sampled
         )
@@ -38,7 +38,11 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertEqual(
             traceParent,
-            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: .sampled)
+            TraceParent(
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                parentID: "b7ad6b7169203331",
+                traceFlags: .sampled
+            )
         )
     }
 
@@ -51,7 +55,11 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertEqual(
             traceParent,
-            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: [])
+            TraceParent(
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                parentID: "b7ad6b7169203331",
+                traceFlags: []
+            )
         )
     }
 
@@ -64,7 +72,11 @@ final class TraceParentRawRepresentableTests: XCTestCase {
 
         XCTAssertEqual(
             traceParent,
-            TraceParent(traceID: "0af7651916cd43dd8448eb211c80319c", parentID: "b7ad6b7169203331", traceFlags: [])
+            TraceParent(
+                traceID: TraceID(hexString: "0af7651916cd43dd8448eb211c80319c")!,
+                parentID: "b7ad6b7169203331",
+                traceFlags: []
+            )
         )
 
         XCTAssertFalse(traceParent.traceFlags.contains(.sampled))


### PR DESCRIPTION
Upgrade trace id from a plain `String` to its own `TraceID` struct. This will allow users to make computations, such as comparing the low value to an upper bound (probabilistic sampling).