### PR TITLE
Add SPI info to README 📖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # Swift W3C Trace Context
 
-[![Swift 5.9](https://img.shields.io/badge/Swift-5.9-brightgreen.svg)](https://swift.org/download)
 [![CI](https://github.com/slashmo/swift-w3c-trace-context/actions/workflows/ci.yml/badge.svg)](https://github.com/slashmo/swift-w3c-trace-context/actions/workflows/ci.yml)
+[![Swift](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fslashmo%2Fswift-w3c-trace-context%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/slashmo/swift-w3c-trace-context)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fslashmo%2Fswift-w3c-trace-context%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/slashmo/swift-w3c-trace-context)
 
 A Swift implementation of the [W3C Trace Context](https://www.w3.org/TR/trace-context-1/) standard.
+
+## Documentation
+
+Our documentation is hosted on the
+[Swift Package Index](https://swiftpackageindex.com/slashmo/swift-w3c-trace-context/documentation/w3ctracecontext).
 
 ## Contributing
 


### PR DESCRIPTION
Adds badges from the [Swift Package Index](https://swiftpackageindex.com/slashmo/swift-w3c-trace-context) and a documentation section to the README.