### PR TITLE
Set minimum swift-collections version to 1.1.0 📦

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,16 +6,16 @@ let swiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictConcurren
 let package = Package(
     name: "swift-w3c-trace-context",
     products: [
-        .library(name: "W3CTraceContext", targets: ["W3CTraceContext"])
+        .library(name: "W3CTraceContext", targets: ["W3CTraceContext"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     ],
     targets: [
         .target(
             name: "W3CTraceContext",
             dependencies: [
-                .product(name: "OrderedCollections", package: "swift-collections")
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             swiftSettings: swiftSettings
         ),


### PR DESCRIPTION
We rely on `OrderedDictionary` from `apple/swift-collections` to conform to `Sendable`, but this conformance was only added in [Swift Collections 1.1.0](https://github.com/apple/swift-collections/releases/tag/1.1.0). Previously, the minimum version we depended on was `1.0.0`, potentially leading to issues where users would still pull in a `swift-collections` version without `Sendable` conformances. To mitigate this, we now increased the minimum version to `1.1.0`.