### PR TITLE
Proposal: Expose bytes from TraceID

### DIFF
--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -138,26 +138,13 @@ extension SpanID.Bytes: CustomStringConvertible {
 
     /// A 16 character UTF-8 hex byte array representation of the bytes.
     public var hexBytes: [UInt8] {
-        var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
-        return Swift.withUnsafeMutableBytes(of: &asciiBytes) { ptr in
-            ptr[0] = Hex.lookup[Int(_bytes.0 >> 4)]
-            ptr[1] = Hex.lookup[Int(_bytes.0 & 0x0F)]
-            ptr[2] = Hex.lookup[Int(_bytes.1 >> 4)]
-            ptr[3] = Hex.lookup[Int(_bytes.1 & 0x0F)]
-            ptr[4] = Hex.lookup[Int(_bytes.2 >> 4)]
-            ptr[5] = Hex.lookup[Int(_bytes.2 & 0x0F)]
-            ptr[6] = Hex.lookup[Int(_bytes.3 >> 4)]
-            ptr[7] = Hex.lookup[Int(_bytes.3 & 0x0F)]
-            ptr[8] = Hex.lookup[Int(_bytes.4 >> 4)]
-            ptr[9] = Hex.lookup[Int(_bytes.4 & 0x0F)]
-            ptr[10] = Hex.lookup[Int(_bytes.5 >> 4)]
-            ptr[11] = Hex.lookup[Int(_bytes.5 & 0x0F)]
-            ptr[12] = Hex.lookup[Int(_bytes.6 >> 4)]
-            ptr[13] = Hex.lookup[Int(_bytes.6 & 0x0F)]
-            ptr[14] = Hex.lookup[Int(_bytes.7 >> 4)]
-            ptr[15] = Hex.lookup[Int(_bytes.7 & 0x0F)]
-            return Array(ptr)
+        var asciiBytes = [UInt8](repeating: 0, count: 16)
+        for i in startIndex ..< endIndex {
+            let byte = self[i]
+            asciiBytes[2 * i] = Hex.lookup[Int(byte >> 4)]
+            asciiBytes[2 * i + 1] = Hex.lookup[Int(byte & 0x0F)]
         }
+        return asciiBytes
     }
 }
 

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -31,7 +31,7 @@ public struct SpanID: Sendable {
 
     @inlinable
     public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        try Swift.withUnsafeBytes(of: self.bytes._bytes, body)
+        try Swift.withUnsafeBytes(of: bytes._bytes, body)
     }
 
     /// Create a random span ID using the given random number generator.
@@ -88,16 +88,12 @@ public struct SpanID: Sendable {
             hasher.combine(_bytes.6)
             hasher.combine(_bytes.7)
         }
-    } 
+    }
 }
 
-extension SpanID: Equatable {
-    
-}
+extension SpanID: Equatable {}
 
-extension SpanID: Hashable {
-    
-}
+extension SpanID: Hashable {}
 
 extension SpanID: Identifiable {
     public var id: Bytes { bytes }
@@ -106,13 +102,11 @@ extension SpanID: Identifiable {
 extension SpanID: CustomStringConvertible {
     /// A 16 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: self.bytes.hexBytes, as: UTF8.self)
+        String(decoding: bytes.hexBytes, as: UTF8.self)
     }
-
 }
 
 extension SpanID.Bytes {
-
     /// A 16 character UTF-8 hex byte array representation of the span ID.
     public var hexBytes: [UInt8] {
         var asciiBytes: (UInt64, UInt64) = (0, 0)

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -16,7 +16,7 @@
 ///
 /// [W3C TraceContext: parent-id](https://www.w3.org/TR/trace-context-1/#parent-id)
 public struct SpanID: Sendable {
-    private let bytes: Bytes
+    public let bytes: Bytes
 
     /// Create a span ID from 8 bytes.
     ///
@@ -29,7 +29,8 @@ public struct SpanID: Sendable {
         self.bytes = Bytes(bytes)
     }
 
-    func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+    @inlinable
+    public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
         try Swift.withUnsafeBytes(of: self.bytes._bytes, body)
     }
 
@@ -55,7 +56,7 @@ public struct SpanID: Sendable {
 
     /// An 8-byte array.
     public struct Bytes: Equatable, Hashable, Sendable {
-        
+        @usableFromInline
         let _bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 
         public init(_ bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -26,9 +26,6 @@ public struct SpanID: Sendable {
         self.bytes = bytes
     }
 
-    /// An invalid span ID with all bytes set to 0.
-    public static var invalid: SpanID { SpanID(bytes: .null) }
-
     /// Create a random span ID using the given random number generator.
     ///
     /// - Parameter randomNumberGenerator: The random number generator used to create random bytes for the span ID.

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -26,13 +26,8 @@ public struct SpanID: Sendable {
         self.bytes = bytes
     }
 
-    @inlinable
-    public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        try bytes.withUnsafeBytes(body)
-    }
-
-    /// A null span ID.
-    public static var null: SpanID { SpanID(bytes: .null) }
+    /// An invalid span ID with all bytes set to 0.
+    public static var invalid: SpanID { SpanID(bytes: .null) }
 
     /// Create a random span ID using the given random number generator.
     ///
@@ -88,19 +83,25 @@ public struct SpanID: Sendable {
         public var endIndex: Int { 8 }
 
         @inlinable
-        public func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R? {
+        public func withContiguousStorageIfAvailable<Result>(_ body: (UnsafeBufferPointer<UInt8>) throws -> Result) rethrows -> Result? {
             try Swift.withUnsafeBytes(of: _bytes) { bytes in
                 try bytes.withMemoryRebound(to: UInt8.self, body)
             }
         }
 
+        /// Calls the given closure with a pointer to the span ID's underlying bytes.
+        ///
+        /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the span ID's underlying bytes.
         @inlinable
         public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
             try Swift.withUnsafeBytes(of: _bytes, body)
         }
 
+        /// Calls the given closure with a mutable pointer to the span ID's underlying bytes.
+        ///
+        /// - Parameter body: A closure receiving an `UnsafeMutableRawBufferPointer` to the span ID's underlying bytes.
         @inlinable
-        public mutating func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
+        public mutating func withUnsafeMutableBytes<Result>(_ body: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
             try Swift.withUnsafeMutableBytes(of: &_bytes) { bytes in
                 try body(bytes)
             }
@@ -159,7 +160,7 @@ extension SpanID: Identifiable {
 extension SpanID: CustomStringConvertible {
     /// A 16 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: bytes.hexBytes, as: UTF8.self)
+        "\(bytes)"
     }
 
     /// A 16 character UTF-8 hex byte array representation of the span ID.

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -48,7 +48,26 @@ public struct SpanID: Sendable {
         var generator = SystemRandomNumberGenerator()
         return random(using: &generator)
     }
+}
 
+extension SpanID: Equatable {}
+
+extension SpanID: Hashable {}
+
+extension SpanID: Identifiable {
+    public var id: Self { self }
+}
+
+extension SpanID: CustomStringConvertible {
+    /// A 16 character hex string representation of the span ID.
+    public var description: String {
+        "\(bytes)"
+    }
+}
+
+// MARK: - Bytes
+
+extension SpanID {
     /// An 8-byte array.
     public struct Bytes: Collection, Equatable, Hashable, Sendable {
         public static var null: Self { SpanID.Bytes((0, 0, 0, 0, 0, 0, 0, 0)) }
@@ -83,7 +102,9 @@ public struct SpanID: Sendable {
         public var endIndex: Int { 8 }
 
         @inlinable
-        public func withContiguousStorageIfAvailable<Result>(_ body: (UnsafeBufferPointer<UInt8>) throws -> Result) rethrows -> Result? {
+        public func withContiguousStorageIfAvailable<Result>(
+            _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
+        ) rethrows -> Result? {
             try Swift.withUnsafeBytes(of: _bytes) { bytes in
                 try bytes.withMemoryRebound(to: UInt8.self, body)
             }
@@ -101,7 +122,9 @@ public struct SpanID: Sendable {
         ///
         /// - Parameter body: A closure receiving an `UnsafeMutableRawBufferPointer` to the span ID's underlying bytes.
         @inlinable
-        public mutating func withUnsafeMutableBytes<Result>(_ body: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+        public mutating func withUnsafeMutableBytes<Result>(
+            _ body: (UnsafeMutableRawBufferPointer) throws -> Result
+        ) rethrows -> Result {
             try Swift.withUnsafeMutableBytes(of: &_bytes) { bytes in
                 try body(bytes)
             }
@@ -146,25 +169,5 @@ extension SpanID.Bytes: CustomStringConvertible {
             asciiBytes[2 * i + 1] = Hex.lookup[Int(byte & 0x0F)]
         }
         return asciiBytes
-    }
-}
-
-extension SpanID: Equatable {}
-
-extension SpanID: Hashable {}
-
-extension SpanID: Identifiable {
-    public var id: Self { self }
-}
-
-extension SpanID: CustomStringConvertible {
-    /// A 16 character hex string representation of the span ID.
-    public var description: String {
-        "\(bytes)"
-    }
-
-    /// A 16 character UTF-8 hex byte array representation of the span ID.
-    public var hexBytes: [UInt8] {
-        bytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -69,27 +69,11 @@ public struct TraceContext: Sendable {
 
         // trace ID
 
-        var traceIDBytes = TraceID.Bytes(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var traceIDBytes = TraceID.Bytes.null
         withUnsafeMutableBytes(of: &traceIDBytes) { ptr in
             Hex.convert(traceParent[3 ..< 35], toBytes: ptr)
         }
-        if traceIDBytes._bytes.0 == 0,
-           traceIDBytes._bytes.1 == 0,
-           traceIDBytes._bytes.2 == 0,
-           traceIDBytes._bytes.3 == 0,
-           traceIDBytes._bytes.4 == 0,
-           traceIDBytes._bytes.5 == 0,
-           traceIDBytes._bytes.6 == 0,
-           traceIDBytes._bytes.7 == 0,
-           traceIDBytes._bytes.8 == 0,
-           traceIDBytes._bytes.9 == 0,
-           traceIDBytes._bytes.10 == 0,
-           traceIDBytes._bytes.11 == 0,
-           traceIDBytes._bytes.12 == 0,
-           traceIDBytes._bytes.13 == 0,
-           traceIDBytes._bytes.14 == 0,
-           traceIDBytes._bytes.15 == 0
-        {
+        if traceIDBytes == .null {
             throw TraceParentDecodingError(
                 .invalidTraceID(String(decoding: traceParent[3 ..< 35], as: UTF8.self))
             )
@@ -97,19 +81,11 @@ public struct TraceContext: Sendable {
 
         // span ID
 
-        var spanIDBytes = SpanID.Bytes(0, 0, 0, 0, 0, 0, 0, 0)
-        withUnsafeMutableBytes(of: &spanIDBytes) { ptr in
+        var spanIDBytes = SpanID.Bytes.null
+        spanIDBytes.withUnsafeMutableBytes { ptr in
             Hex.convert(traceParent[36 ..< 52], toBytes: ptr)
         }
-        if spanIDBytes._bytes.0 == 0,
-           spanIDBytes._bytes.1 == 0,
-           spanIDBytes._bytes.2 == 0,
-           spanIDBytes._bytes.3 == 0,
-           spanIDBytes._bytes.4 == 0,
-           spanIDBytes._bytes.5 == 0,
-           spanIDBytes._bytes.6 == 0,
-           spanIDBytes._bytes.7 == 0
-        {
+        if spanIDBytes == .null {
             throw TraceParentDecodingError(
                 .invalidSpanID(String(decoding: traceParent[36 ..< 52], as: UTF8.self))
             )

--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -69,7 +69,7 @@ public struct TraceContext: Sendable {
 
         // trace ID
 
-        var traceIDBytes = TraceID.Bytes(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var traceIDBytes = TraceID.Bytes.Storage(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutableBytes(of: &traceIDBytes) { ptr in
             Hex.convert(traceParent[3 ..< 35], toBytes: ptr)
         }
@@ -130,7 +130,7 @@ public struct TraceContext: Sendable {
         }
 
         self = TraceContext(
-            traceID: TraceID(bytes: traceIDBytes),
+            traceID: TraceID(bytes: .init(traceIDBytes)),
             spanID: SpanID(bytes: spanIDBytes),
             flags: flags,
             state: state

--- a/Sources/W3CTraceContext/TraceContext.swift
+++ b/Sources/W3CTraceContext/TraceContext.swift
@@ -69,26 +69,26 @@ public struct TraceContext: Sendable {
 
         // trace ID
 
-        var traceIDBytes = TraceID.Bytes.Storage(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var traceIDBytes = TraceID.Bytes(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutableBytes(of: &traceIDBytes) { ptr in
             Hex.convert(traceParent[3 ..< 35], toBytes: ptr)
         }
-        if traceIDBytes.0 == 0,
-           traceIDBytes.1 == 0,
-           traceIDBytes.2 == 0,
-           traceIDBytes.3 == 0,
-           traceIDBytes.4 == 0,
-           traceIDBytes.5 == 0,
-           traceIDBytes.6 == 0,
-           traceIDBytes.7 == 0,
-           traceIDBytes.8 == 0,
-           traceIDBytes.9 == 0,
-           traceIDBytes.10 == 0,
-           traceIDBytes.11 == 0,
-           traceIDBytes.12 == 0,
-           traceIDBytes.13 == 0,
-           traceIDBytes.14 == 0,
-           traceIDBytes.15 == 0
+        if traceIDBytes._bytes.0 == 0,
+           traceIDBytes._bytes.1 == 0,
+           traceIDBytes._bytes.2 == 0,
+           traceIDBytes._bytes.3 == 0,
+           traceIDBytes._bytes.4 == 0,
+           traceIDBytes._bytes.5 == 0,
+           traceIDBytes._bytes.6 == 0,
+           traceIDBytes._bytes.7 == 0,
+           traceIDBytes._bytes.8 == 0,
+           traceIDBytes._bytes.9 == 0,
+           traceIDBytes._bytes.10 == 0,
+           traceIDBytes._bytes.11 == 0,
+           traceIDBytes._bytes.12 == 0,
+           traceIDBytes._bytes.13 == 0,
+           traceIDBytes._bytes.14 == 0,
+           traceIDBytes._bytes.15 == 0
         {
             throw TraceParentDecodingError(
                 .invalidTraceID(String(decoding: traceParent[3 ..< 35], as: UTF8.self))
@@ -101,14 +101,14 @@ public struct TraceContext: Sendable {
         withUnsafeMutableBytes(of: &spanIDBytes) { ptr in
             Hex.convert(traceParent[36 ..< 52], toBytes: ptr)
         }
-        if spanIDBytes.0 == 0,
-           spanIDBytes.1 == 0,
-           spanIDBytes.2 == 0,
-           spanIDBytes.3 == 0,
-           spanIDBytes.4 == 0,
-           spanIDBytes.5 == 0,
-           spanIDBytes.6 == 0,
-           spanIDBytes.7 == 0
+        if spanIDBytes._bytes.0 == 0,
+           spanIDBytes._bytes.1 == 0,
+           spanIDBytes._bytes.2 == 0,
+           spanIDBytes._bytes.3 == 0,
+           spanIDBytes._bytes.4 == 0,
+           spanIDBytes._bytes.5 == 0,
+           spanIDBytes._bytes.6 == 0,
+           spanIDBytes._bytes.7 == 0
         {
             throw TraceParentDecodingError(
                 .invalidSpanID(String(decoding: traceParent[36 ..< 52], as: UTF8.self))
@@ -130,7 +130,7 @@ public struct TraceContext: Sendable {
         }
 
         self = TraceContext(
-            traceID: TraceID(bytes: .init(traceIDBytes)),
+            traceID: TraceID(bytes: traceIDBytes),
             spanID: SpanID(bytes: spanIDBytes),
             flags: flags,
             state: state

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -16,26 +16,26 @@
 ///
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
-    /// The 16-bytes of the trace ID.
-    public let bytes: Bytes
+    /// The 16 bytes of the trace ID.
+    public let rawBytes: Bytes
 
     /// A 16-byte array representation of the trace ID.
-    public var bytesArray: [UInt8] {
-        withUnsafeBytes(of: bytes, Array.init)
+    public var bytes: [UInt8] {
+        withUnsafeBytes(of: rawBytes, Array.init)
     }
 
     /// Create a trace ID from 16 bytes.
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: Bytes) {
-        self.bytes = bytes
+        self.rawBytes = bytes
     }
 
     /// Create a trace ID from 16 bytes.
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: Bytes.Storage) {
-        self.bytes = .init(bytes)
+        self.rawBytes = .init(bytes)
     }
 
     /// Create a random trace ID using the given random number generator.
@@ -67,10 +67,33 @@ public struct TraceID: Sendable {
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )
 
-        /* private */ public let _storage: Storage
+        @usableFromInline
+        /* private */ let _storage: Storage
 
         public init(_ bytes: Storage) {
             self._storage = bytes
+        }
+
+        public init(
+            _ one: UInt8,
+            _ two: UInt8,
+            _ three: UInt8,
+            _ four: UInt8,
+            _ five: UInt8,
+            _ six: UInt8,
+            _ seven: UInt8,
+            _ eight: UInt8,
+            _ nine: UInt8,
+            _ ten: UInt8,
+            _ eleven: UInt8,
+            _ twelve: UInt8,
+            _ thirteen: UInt8,
+            _ fourteen: UInt8,
+            _ fifteen: UInt8,
+            _ sixteen: UInt8
+        ) {
+            self._storage = (one, two, three, four, five, six, seven, eight,
+                             nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen)
         }
 
         public var array: [UInt8] {
@@ -133,7 +156,7 @@ extension TraceID.Bytes: Hashable {
 }
 
 extension TraceID: Identifiable {
-    public var id: Bytes { bytes }
+    public var id: Bytes { rawBytes }
 }
 
 extension TraceID.Bytes: CustomStringConvertible {
@@ -142,7 +165,7 @@ extension TraceID.Bytes: CustomStringConvertible {
         String(decoding: hexBytes, as: UTF8.self)
     }
 
-    /// A 32 character UTF-8 hex byte array representation of the bytes ID.
+    /// A 32 character UTF-8 hex byte array representation of the bytes.
     public var hexBytes: [UInt8] {
         var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
         return withUnsafeMutableBytes(of: &asciiBytes) { ptr in
@@ -186,11 +209,11 @@ extension TraceID.Bytes: CustomStringConvertible {
 extension TraceID: CustomStringConvertible {
     /// A 32 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: self.bytes.hexBytes, as: UTF8.self)
+        String(decoding: self.rawBytes.hexBytes, as: UTF8.self)
     }
 
     /// A 32 character UTF-8 hex byte array representation of the span ID.
     public var hexBytes: [UInt8] {
-        self.bytes.hexBytes
+        self.rawBytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -29,8 +29,16 @@ public struct TraceID: Sendable {
     /// Create a trace ID from 16 bytes.
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
-    public init(bytes: Bytes.Storage) {
+    public init(bytes: (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        )) {
         self.bytes = .init(bytes)
+    }
+
+    /// Access the bytes of the trace ID in an unsafe manner.
+    public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+        try Swift.withUnsafeBytes(of: self.bytes._bytes, body)
     }
 
     /// Create a random trace ID using the given random number generator.
@@ -38,12 +46,12 @@ public struct TraceID: Sendable {
     /// - Parameter randomNumberGenerator: The random number generator used to create random bytes for the trace ID.
     /// - Returns: A random trace ID.
     public static func random(using randomNumberGenerator: inout some RandomNumberGenerator) -> TraceID {
-        var bytes: TraceID.Bytes.Storage = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var bytes: TraceID.Bytes = .init(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutableBytes(of: &bytes) { ptr in
             ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, as: UInt64.self)
             ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, toByteOffset: 8, as: UInt64.self)
         }
-        return TraceID(bytes: .init(bytes))
+        return TraceID(bytes: bytes)
     }
 
     /// Create a random trace ID.
@@ -56,17 +64,16 @@ public struct TraceID: Sendable {
 
     /// A 16-byte array.
     public struct Bytes: Sendable {
-    
-        public typealias Storage = (
+        let _bytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )
 
-        @usableFromInline
-        /* private */ let _storage: Storage
-
-        public init(_ bytes: Storage) {
-            self._storage = bytes
+        public init(_ bytes: (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        )) {
+            self._bytes = bytes
         }
 
         public init(
@@ -87,19 +94,8 @@ public struct TraceID: Sendable {
             _ fifteen: UInt8,
             _ sixteen: UInt8
         ) {
-            self._storage = (one, two, three, four, five, six, seven, eight,
+            self._bytes = (one, two, three, four, five, six, seven, eight,
                              nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen)
-        }
-
-        public var array: [UInt8] {
-            Swift.withUnsafeBytes(of: _storage, Array.init)
-        }
-
-        @inlinable
-        public func withUnsafeBytes<Result>(
-            _ body: (UnsafeRawBufferPointer) throws -> Result
-        ) rethrows -> Result {
-            try Swift.withUnsafeBytes(of: _storage, body)
         }
 
     }
@@ -110,43 +106,43 @@ extension TraceID : Hashable {}
 
 extension TraceID.Bytes: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs._storage.0 == rhs._storage.0
-            && lhs._storage.1 == rhs._storage.1
-            && lhs._storage.2 == rhs._storage.2
-            && lhs._storage.3 == rhs._storage.3
-            && lhs._storage.4 == rhs._storage.4
-            && lhs._storage.5 == rhs._storage.5
-            && lhs._storage.6 == rhs._storage.6
-            && lhs._storage.7 == rhs._storage.7
-            && lhs._storage.8 == rhs._storage.8
-            && lhs._storage.9 == rhs._storage.9
-            && lhs._storage.10 == rhs._storage.10
-            && lhs._storage.11 == rhs._storage.11
-            && lhs._storage.12 == rhs._storage.12
-            && lhs._storage.13 == rhs._storage.13
-            && lhs._storage.14 == rhs._storage.14
-            && lhs._storage.15 == rhs._storage.15
+        lhs._bytes.0 == rhs._bytes.0
+            && lhs._bytes.1 == rhs._bytes.1
+            && lhs._bytes.2 == rhs._bytes.2
+            && lhs._bytes.3 == rhs._bytes.3
+            && lhs._bytes.4 == rhs._bytes.4
+            && lhs._bytes.5 == rhs._bytes.5
+            && lhs._bytes.6 == rhs._bytes.6
+            && lhs._bytes.7 == rhs._bytes.7
+            && lhs._bytes.8 == rhs._bytes.8
+            && lhs._bytes.9 == rhs._bytes.9
+            && lhs._bytes.10 == rhs._bytes.10
+            && lhs._bytes.11 == rhs._bytes.11
+            && lhs._bytes.12 == rhs._bytes.12
+            && lhs._bytes.13 == rhs._bytes.13
+            && lhs._bytes.14 == rhs._bytes.14
+            && lhs._bytes.15 == rhs._bytes.15
     }
 }
 
 extension TraceID.Bytes: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_storage.0)
-        hasher.combine(_storage.1)
-        hasher.combine(_storage.2)
-        hasher.combine(_storage.3)
-        hasher.combine(_storage.4)
-        hasher.combine(_storage.5)
-        hasher.combine(_storage.6)
-        hasher.combine(_storage.7)
-        hasher.combine(_storage.8)
-        hasher.combine(_storage.9)
-        hasher.combine(_storage.10)
-        hasher.combine(_storage.11)
-        hasher.combine(_storage.12)
-        hasher.combine(_storage.13)
-        hasher.combine(_storage.14)
-        hasher.combine(_storage.15)
+        hasher.combine(_bytes.0)
+        hasher.combine(_bytes.1)
+        hasher.combine(_bytes.2)
+        hasher.combine(_bytes.3)
+        hasher.combine(_bytes.4)
+        hasher.combine(_bytes.5)
+        hasher.combine(_bytes.6)
+        hasher.combine(_bytes.7)
+        hasher.combine(_bytes.8)
+        hasher.combine(_bytes.9)
+        hasher.combine(_bytes.10)
+        hasher.combine(_bytes.11)
+        hasher.combine(_bytes.12)
+        hasher.combine(_bytes.13)
+        hasher.combine(_bytes.14)
+        hasher.combine(_bytes.15)
     }
 }
 
@@ -164,38 +160,38 @@ extension TraceID.Bytes: CustomStringConvertible {
     public var hexBytes: [UInt8] {
         var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
         return withUnsafeMutableBytes(of: &asciiBytes) { ptr in
-            ptr[0] = Hex.lookup[Int(_storage.0 >> 4)]
-            ptr[1] = Hex.lookup[Int(_storage.0 & 0x0F)]
-            ptr[2] = Hex.lookup[Int(_storage.1 >> 4)]
-            ptr[3] = Hex.lookup[Int(_storage.1 & 0x0F)]
-            ptr[4] = Hex.lookup[Int(_storage.2 >> 4)]
-            ptr[5] = Hex.lookup[Int(_storage.2 & 0x0F)]
-            ptr[6] = Hex.lookup[Int(_storage.3 >> 4)]
-            ptr[7] = Hex.lookup[Int(_storage.3 & 0x0F)]
-            ptr[8] = Hex.lookup[Int(_storage.4 >> 4)]
-            ptr[9] = Hex.lookup[Int(_storage.4 & 0x0F)]
-            ptr[10] = Hex.lookup[Int(_storage.5 >> 4)]
-            ptr[11] = Hex.lookup[Int(_storage.5 & 0x0F)]
-            ptr[12] = Hex.lookup[Int(_storage.6 >> 4)]
-            ptr[13] = Hex.lookup[Int(_storage.6 & 0x0F)]
-            ptr[14] = Hex.lookup[Int(_storage.7 >> 4)]
-            ptr[15] = Hex.lookup[Int(_storage.7 & 0x0F)]
-            ptr[16] = Hex.lookup[Int(_storage.8 >> 4)]
-            ptr[17] = Hex.lookup[Int(_storage.8 & 0x0F)]
-            ptr[18] = Hex.lookup[Int(_storage.9 >> 4)]
-            ptr[19] = Hex.lookup[Int(_storage.9 & 0x0F)]
-            ptr[20] = Hex.lookup[Int(_storage.10 >> 4)]
-            ptr[21] = Hex.lookup[Int(_storage.10 & 0x0F)]
-            ptr[22] = Hex.lookup[Int(_storage.11 >> 4)]
-            ptr[23] = Hex.lookup[Int(_storage.11 & 0x0F)]
-            ptr[24] = Hex.lookup[Int(_storage.12 >> 4)]
-            ptr[25] = Hex.lookup[Int(_storage.12 & 0x0F)]
-            ptr[26] = Hex.lookup[Int(_storage.13 >> 4)]
-            ptr[27] = Hex.lookup[Int(_storage.13 & 0x0F)]
-            ptr[28] = Hex.lookup[Int(_storage.14 >> 4)]
-            ptr[29] = Hex.lookup[Int(_storage.14 & 0x0F)]
-            ptr[30] = Hex.lookup[Int(_storage.15 >> 4)]
-            ptr[31] = Hex.lookup[Int(_storage.15 & 0x0F)]
+            ptr[0] = Hex.lookup[Int(_bytes.0 >> 4)]
+            ptr[1] = Hex.lookup[Int(_bytes.0 & 0x0F)]
+            ptr[2] = Hex.lookup[Int(_bytes.1 >> 4)]
+            ptr[3] = Hex.lookup[Int(_bytes.1 & 0x0F)]
+            ptr[4] = Hex.lookup[Int(_bytes.2 >> 4)]
+            ptr[5] = Hex.lookup[Int(_bytes.2 & 0x0F)]
+            ptr[6] = Hex.lookup[Int(_bytes.3 >> 4)]
+            ptr[7] = Hex.lookup[Int(_bytes.3 & 0x0F)]
+            ptr[8] = Hex.lookup[Int(_bytes.4 >> 4)]
+            ptr[9] = Hex.lookup[Int(_bytes.4 & 0x0F)]
+            ptr[10] = Hex.lookup[Int(_bytes.5 >> 4)]
+            ptr[11] = Hex.lookup[Int(_bytes.5 & 0x0F)]
+            ptr[12] = Hex.lookup[Int(_bytes.6 >> 4)]
+            ptr[13] = Hex.lookup[Int(_bytes.6 & 0x0F)]
+            ptr[14] = Hex.lookup[Int(_bytes.7 >> 4)]
+            ptr[15] = Hex.lookup[Int(_bytes.7 & 0x0F)]
+            ptr[16] = Hex.lookup[Int(_bytes.8 >> 4)]
+            ptr[17] = Hex.lookup[Int(_bytes.8 & 0x0F)]
+            ptr[18] = Hex.lookup[Int(_bytes.9 >> 4)]
+            ptr[19] = Hex.lookup[Int(_bytes.9 & 0x0F)]
+            ptr[20] = Hex.lookup[Int(_bytes.10 >> 4)]
+            ptr[21] = Hex.lookup[Int(_bytes.10 & 0x0F)]
+            ptr[22] = Hex.lookup[Int(_bytes.11 >> 4)]
+            ptr[23] = Hex.lookup[Int(_bytes.11 & 0x0F)]
+            ptr[24] = Hex.lookup[Int(_bytes.12 >> 4)]
+            ptr[25] = Hex.lookup[Int(_bytes.12 & 0x0F)]
+            ptr[26] = Hex.lookup[Int(_bytes.13 >> 4)]
+            ptr[27] = Hex.lookup[Int(_bytes.13 & 0x0F)]
+            ptr[28] = Hex.lookup[Int(_bytes.14 >> 4)]
+            ptr[29] = Hex.lookup[Int(_bytes.14 & 0x0F)]
+            ptr[30] = Hex.lookup[Int(_bytes.15 >> 4)]
+            ptr[31] = Hex.lookup[Int(_bytes.15 & 0x0F)]
             return Array(ptr)
         }
     }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -26,9 +26,6 @@ public struct TraceID: Sendable {
         self.bytes = bytes
     }
 
-    /// An invalid trace ID with all bytes set to 0.
-    public static var invalid: TraceID { TraceID(bytes: .null) }
-
     /// Create a random trace ID using the given random number generator.
     ///
     /// - Parameter randomNumberGenerator: The random number generator used to create random bytes for the trace ID.

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -30,16 +30,16 @@ public struct TraceID: Sendable {
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: (
-            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
-        )) {
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+    )) {
         self.bytes = .init(bytes)
     }
 
     /// Access the bytes of the trace ID in an unsafe manner.
     @inlinable
     public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        try Swift.withUnsafeBytes(of: self.bytes._bytes, body)
+        try Swift.withUnsafeBytes(of: bytes._bytes, body)
     }
 
     /// Create a random trace ID using the given random number generator.
@@ -74,7 +74,7 @@ public struct TraceID: Sendable {
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )) {
-            self._bytes = bytes
+            _bytes = bytes
         }
 
         public init(
@@ -95,15 +95,30 @@ public struct TraceID: Sendable {
             _ fifteen: UInt8,
             _ sixteen: UInt8
         ) {
-            self._bytes = (one, two, three, four, five, six, seven, eight,
-                             nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen)
+            _bytes = (
+                one,
+                two,
+                three,
+                four,
+                five,
+                six,
+                seven,
+                eight,
+                nine,
+                ten,
+                eleven,
+                twelve,
+                thirteen,
+                fourteen,
+                fifteen,
+                sixteen
+            )
         }
-
     }
 }
 
-extension TraceID : Equatable {}
-extension TraceID : Hashable {}
+extension TraceID: Equatable {}
+extension TraceID: Hashable {}
 
 extension TraceID.Bytes: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
@@ -201,11 +216,11 @@ extension TraceID.Bytes: CustomStringConvertible {
 extension TraceID: CustomStringConvertible {
     /// A 32 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: self.bytes.hexBytes, as: UTF8.self)
+        String(decoding: bytes.hexBytes, as: UTF8.self)
     }
 
     /// A 32 character UTF-8 hex byte array representation of the span ID.
     public var hexBytes: [UInt8] {
-        self.bytes.hexBytes
+        bytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -16,7 +16,7 @@
 ///
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
-    /// The 16 bytes of the trace ID.
+    /// The 16 bytes making up the trace ID.
     public let bytes: Bytes
 
     /// Create a trace ID from 16 bytes.
@@ -26,31 +26,25 @@ public struct TraceID: Sendable {
         self.bytes = bytes
     }
 
-    /// Create a trace ID from 16 bytes.
-    ///
-    /// - Parameter bytes: The 16 bytes making up the trace ID.
-    public init(bytes: (
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
-    )) {
-        self.bytes = .init(bytes)
-    }
-
-    /// Access the bytes of the trace ID in an unsafe manner.
     @inlinable
     public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        try Swift.withUnsafeBytes(of: bytes._bytes, body)
+        try bytes.withUnsafeBytes(body)
     }
+
+    /// A null trace ID.
+    public static var null: TraceID { TraceID(bytes: .null) }
 
     /// Create a random trace ID using the given random number generator.
     ///
     /// - Parameter randomNumberGenerator: The random number generator used to create random bytes for the trace ID.
     /// - Returns: A random trace ID.
     public static func random(using randomNumberGenerator: inout some RandomNumberGenerator) -> TraceID {
-        var bytes: TraceID.Bytes = .init(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        withUnsafeMutableBytes(of: &bytes) { ptr in
-            ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, as: UInt64.self)
-            ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, toByteOffset: 8, as: UInt64.self)
+        var bytes: TraceID.Bytes = .null
+        bytes.withUnsafeMutableBytes { ptr in
+            let rand1 = randomNumberGenerator.next()
+            let rand2 = randomNumberGenerator.next()
+            ptr.storeBytes(of: rand1.bigEndian, toByteOffset: 0, as: UInt64.self)
+            ptr.storeBytes(of: rand2.bigEndian, toByteOffset: 8, as: UInt64.self)
         }
         return TraceID(bytes: bytes)
     }
@@ -64,8 +58,11 @@ public struct TraceID: Sendable {
     }
 
     /// A 16-byte array.
-    public struct Bytes: Sendable {
-        @usableFromInline let _bytes: (
+    public struct Bytes: Collection, Equatable, Hashable, Sendable {
+        public static var null: Self { TraceID.Bytes((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) }
+
+        @usableFromInline
+        var _bytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )
@@ -77,149 +74,134 @@ public struct TraceID: Sendable {
             _bytes = bytes
         }
 
-        public init(
-            _ one: UInt8,
-            _ two: UInt8,
-            _ three: UInt8,
-            _ four: UInt8,
-            _ five: UInt8,
-            _ six: UInt8,
-            _ seven: UInt8,
-            _ eight: UInt8,
-            _ nine: UInt8,
-            _ ten: UInt8,
-            _ eleven: UInt8,
-            _ twelve: UInt8,
-            _ thirteen: UInt8,
-            _ fourteen: UInt8,
-            _ fifteen: UInt8,
-            _ sixteen: UInt8
-        ) {
-            _bytes = (
-                one,
-                two,
-                three,
-                four,
-                five,
-                six,
-                seven,
-                eight,
-                nine,
-                ten,
-                eleven,
-                twelve,
-                thirteen,
-                fourteen,
-                fifteen,
-                sixteen
-            )
+        public subscript(position: Int) -> UInt8 {
+            switch position {
+            case 0: _bytes.0
+            case 1: _bytes.1
+            case 2: _bytes.2
+            case 3: _bytes.3
+            case 4: _bytes.4
+            case 5: _bytes.5
+            case 6: _bytes.6
+            case 7: _bytes.7
+            case 8: _bytes.8
+            case 9: _bytes.9
+            case 10: _bytes.10
+            case 11: _bytes.11
+            case 12: _bytes.12
+            case 13: _bytes.13
+            case 14: _bytes.14
+            case 15: _bytes.15
+            default: fatalError("Index out of range")
+            }
+        }
+
+        public func index(after i: Int) -> Int {
+            precondition(i < endIndex, "Can't advance beyond endIndex")
+            return i + 1
+        }
+
+        public var startIndex: Int { 0 }
+        public var endIndex: Int { 16 }
+
+        @inlinable
+        public func withContiguousStorageIfAvailable<R>(
+            _ body: (UnsafeBufferPointer<UInt8>) throws -> R
+        ) rethrows -> R? {
+            try Swift.withUnsafeBytes(of: _bytes) { bytes in
+                try bytes.withMemoryRebound(to: UInt8.self, body)
+            }
+        }
+
+        @inlinable
+        public func withUnsafeBytes<Result>(
+            _ body: (UnsafeRawBufferPointer) throws -> Result
+        ) rethrows -> Result {
+            try Swift.withUnsafeBytes(of: _bytes, body)
+        }
+
+        @inlinable
+        public mutating func withUnsafeMutableBytes<R>(
+            _ body: (UnsafeMutableRawBufferPointer) throws -> R
+        ) rethrows -> R {
+            try Swift.withUnsafeMutableBytes(of: &_bytes) { bytes in
+                try body(bytes)
+            }
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs._bytes.0 == rhs._bytes.0 &&
+                lhs._bytes.1 == rhs._bytes.1 &&
+                lhs._bytes.2 == rhs._bytes.2 &&
+                lhs._bytes.3 == rhs._bytes.3 &&
+                lhs._bytes.4 == rhs._bytes.4 &&
+                lhs._bytes.5 == rhs._bytes.5 &&
+                lhs._bytes.6 == rhs._bytes.6 &&
+                lhs._bytes.7 == rhs._bytes.7 &&
+                lhs._bytes.8 == rhs._bytes.8 &&
+                lhs._bytes.9 == rhs._bytes.9 &&
+                lhs._bytes.10 == rhs._bytes.10 &&
+                lhs._bytes.11 == rhs._bytes.11 &&
+                lhs._bytes.12 == rhs._bytes.12 &&
+                lhs._bytes.13 == rhs._bytes.13 &&
+                lhs._bytes.14 == rhs._bytes.14 &&
+                lhs._bytes.15 == rhs._bytes.15
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(_bytes.0)
+            hasher.combine(_bytes.1)
+            hasher.combine(_bytes.2)
+            hasher.combine(_bytes.3)
+            hasher.combine(_bytes.4)
+            hasher.combine(_bytes.5)
+            hasher.combine(_bytes.6)
+            hasher.combine(_bytes.7)
+            hasher.combine(_bytes.8)
+            hasher.combine(_bytes.9)
+            hasher.combine(_bytes.10)
+            hasher.combine(_bytes.11)
+            hasher.combine(_bytes.12)
+            hasher.combine(_bytes.13)
+            hasher.combine(_bytes.14)
+            hasher.combine(_bytes.15)
         }
     }
 }
 
-extension TraceID: Equatable {}
-extension TraceID: Hashable {}
-
-extension TraceID.Bytes: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs._bytes.0 == rhs._bytes.0
-            && lhs._bytes.1 == rhs._bytes.1
-            && lhs._bytes.2 == rhs._bytes.2
-            && lhs._bytes.3 == rhs._bytes.3
-            && lhs._bytes.4 == rhs._bytes.4
-            && lhs._bytes.5 == rhs._bytes.5
-            && lhs._bytes.6 == rhs._bytes.6
-            && lhs._bytes.7 == rhs._bytes.7
-            && lhs._bytes.8 == rhs._bytes.8
-            && lhs._bytes.9 == rhs._bytes.9
-            && lhs._bytes.10 == rhs._bytes.10
-            && lhs._bytes.11 == rhs._bytes.11
-            && lhs._bytes.12 == rhs._bytes.12
-            && lhs._bytes.13 == rhs._bytes.13
-            && lhs._bytes.14 == rhs._bytes.14
-            && lhs._bytes.15 == rhs._bytes.15
-    }
-}
-
-extension TraceID.Bytes: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(_bytes.0)
-        hasher.combine(_bytes.1)
-        hasher.combine(_bytes.2)
-        hasher.combine(_bytes.3)
-        hasher.combine(_bytes.4)
-        hasher.combine(_bytes.5)
-        hasher.combine(_bytes.6)
-        hasher.combine(_bytes.7)
-        hasher.combine(_bytes.8)
-        hasher.combine(_bytes.9)
-        hasher.combine(_bytes.10)
-        hasher.combine(_bytes.11)
-        hasher.combine(_bytes.12)
-        hasher.combine(_bytes.13)
-        hasher.combine(_bytes.14)
-        hasher.combine(_bytes.15)
-    }
-}
-
-extension TraceID: Identifiable {
-    public var id: Bytes { bytes }
-}
-
 extension TraceID.Bytes: CustomStringConvertible {
-    /// A 32 character hex string representation of the bytes.
+    /// A 32-character hex string representation of the bytes.
     public var description: String {
         String(decoding: hexBytes, as: UTF8.self)
     }
 
-    /// A 32 character UTF-8 hex byte array representation of the bytes.
+    /// A 32-character UTF-8 hex byte array representation of the bytes.
     public var hexBytes: [UInt8] {
-        var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
-        return withUnsafeMutableBytes(of: &asciiBytes) { ptr in
-            ptr[0] = Hex.lookup[Int(_bytes.0 >> 4)]
-            ptr[1] = Hex.lookup[Int(_bytes.0 & 0x0F)]
-            ptr[2] = Hex.lookup[Int(_bytes.1 >> 4)]
-            ptr[3] = Hex.lookup[Int(_bytes.1 & 0x0F)]
-            ptr[4] = Hex.lookup[Int(_bytes.2 >> 4)]
-            ptr[5] = Hex.lookup[Int(_bytes.2 & 0x0F)]
-            ptr[6] = Hex.lookup[Int(_bytes.3 >> 4)]
-            ptr[7] = Hex.lookup[Int(_bytes.3 & 0x0F)]
-            ptr[8] = Hex.lookup[Int(_bytes.4 >> 4)]
-            ptr[9] = Hex.lookup[Int(_bytes.4 & 0x0F)]
-            ptr[10] = Hex.lookup[Int(_bytes.5 >> 4)]
-            ptr[11] = Hex.lookup[Int(_bytes.5 & 0x0F)]
-            ptr[12] = Hex.lookup[Int(_bytes.6 >> 4)]
-            ptr[13] = Hex.lookup[Int(_bytes.6 & 0x0F)]
-            ptr[14] = Hex.lookup[Int(_bytes.7 >> 4)]
-            ptr[15] = Hex.lookup[Int(_bytes.7 & 0x0F)]
-            ptr[16] = Hex.lookup[Int(_bytes.8 >> 4)]
-            ptr[17] = Hex.lookup[Int(_bytes.8 & 0x0F)]
-            ptr[18] = Hex.lookup[Int(_bytes.9 >> 4)]
-            ptr[19] = Hex.lookup[Int(_bytes.9 & 0x0F)]
-            ptr[20] = Hex.lookup[Int(_bytes.10 >> 4)]
-            ptr[21] = Hex.lookup[Int(_bytes.10 & 0x0F)]
-            ptr[22] = Hex.lookup[Int(_bytes.11 >> 4)]
-            ptr[23] = Hex.lookup[Int(_bytes.11 & 0x0F)]
-            ptr[24] = Hex.lookup[Int(_bytes.12 >> 4)]
-            ptr[25] = Hex.lookup[Int(_bytes.12 & 0x0F)]
-            ptr[26] = Hex.lookup[Int(_bytes.13 >> 4)]
-            ptr[27] = Hex.lookup[Int(_bytes.13 & 0x0F)]
-            ptr[28] = Hex.lookup[Int(_bytes.14 >> 4)]
-            ptr[29] = Hex.lookup[Int(_bytes.14 & 0x0F)]
-            ptr[30] = Hex.lookup[Int(_bytes.15 >> 4)]
-            ptr[31] = Hex.lookup[Int(_bytes.15 & 0x0F)]
-            return Array(ptr)
+        var asciiBytes = [UInt8](repeating: 0, count: 32)
+        for i in 0 ..< 16 {
+            let byte = self[i]
+            asciiBytes[2 * i] = Hex.lookup[Int(byte >> 4)]
+            asciiBytes[2 * i + 1] = Hex.lookup[Int(byte & 0x0F)]
         }
+        return asciiBytes
     }
 }
 
+extension TraceID: Equatable {}
+
+extension TraceID: Hashable {}
+
+extension TraceID: Identifiable {
+    public var id: Self { self }
+}
+
 extension TraceID: CustomStringConvertible {
-    /// A 32 character hex string representation of the span ID.
+    /// A 32-character hex string representation of the trace ID.
     public var description: String {
         String(decoding: bytes.hexBytes, as: UTF8.self)
     }
 
-    /// A 32 character UTF-8 hex byte array representation of the span ID.
+    /// A 32-character UTF-8 hex byte array representation of the trace ID.
     public var hexBytes: [UInt8] {
         bytes.hexBytes
     }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -16,18 +16,26 @@
 ///
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
-    private let _bytes: Bytes
+    /// The 16-bytes of the trace ID.
+    public let bytes: Bytes
 
-    /// A 16-byte array representation of the span ID.
-    public var bytes: [UInt8] {
-        withUnsafeBytes(of: _bytes, Array.init)
+    /// A 16-byte array representation of the trace ID.
+    public var bytesArray: [UInt8] {
+        withUnsafeBytes(of: bytes, Array.init)
     }
 
     /// Create a trace ID from 16 bytes.
     ///
-    /// - Parameter bytes: The eight bytes making up the span ID.
+    /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: Bytes) {
-        _bytes = bytes
+        self.bytes = bytes
+    }
+
+    /// Create a trace ID from 16 bytes.
+    ///
+    /// - Parameter bytes: The 16 bytes making up the trace ID.
+    public init(bytes: Bytes.Storage) {
+        self.bytes = .init(bytes)
     }
 
     /// Create a random trace ID using the given random number generator.
@@ -35,12 +43,12 @@ public struct TraceID: Sendable {
     /// - Parameter randomNumberGenerator: The random number generator used to create random bytes for the trace ID.
     /// - Returns: A random trace ID.
     public static func random(using randomNumberGenerator: inout some RandomNumberGenerator) -> TraceID {
-        var bytes: TraceID.Bytes = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var bytes: TraceID.Bytes.Storage = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutableBytes(of: &bytes) { ptr in
             ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, as: UInt64.self)
             ptr.storeBytes(of: randomNumberGenerator.next().bigEndian, toByteOffset: 8, as: UInt64.self)
         }
-        return TraceID(bytes: bytes)
+        return TraceID(bytes: .init(bytes))
     }
 
     /// Create a random trace ID.
@@ -52,101 +60,137 @@ public struct TraceID: Sendable {
     }
 
     /// A 16-byte array.
-    public typealias Bytes = (
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
-    )
-}
+    public struct Bytes: Sendable {
+    
+        public typealias Storage = (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        )
 
-extension TraceID: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs._bytes.0 == rhs._bytes.0
-            && lhs._bytes.1 == rhs._bytes.1
-            && lhs._bytes.2 == rhs._bytes.2
-            && lhs._bytes.3 == rhs._bytes.3
-            && lhs._bytes.4 == rhs._bytes.4
-            && lhs._bytes.5 == rhs._bytes.5
-            && lhs._bytes.6 == rhs._bytes.6
-            && lhs._bytes.7 == rhs._bytes.7
-            && lhs._bytes.8 == rhs._bytes.8
-            && lhs._bytes.9 == rhs._bytes.9
-            && lhs._bytes.10 == rhs._bytes.10
-            && lhs._bytes.11 == rhs._bytes.11
-            && lhs._bytes.12 == rhs._bytes.12
-            && lhs._bytes.13 == rhs._bytes.13
-            && lhs._bytes.14 == rhs._bytes.14
-            && lhs._bytes.15 == rhs._bytes.15
+        /* private */ public let _storage: Storage
+
+        public init(_ bytes: Storage) {
+            self._storage = bytes
+        }
+
+        public var array: [UInt8] {
+            Swift.withUnsafeBytes(of: _storage, Array.init)
+        }
+
+        @inlinable
+        public func withUnsafeBytes<Result>(
+            _ body: (UnsafeRawBufferPointer) throws -> Result
+        ) rethrows -> Result {
+            try Swift.withUnsafeBytes(of: _storage, body)
+        }
+
     }
 }
 
-extension TraceID: Hashable {
+extension TraceID : Equatable {}
+extension TraceID : Hashable {}
+
+extension TraceID.Bytes: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs._storage.0 == rhs._storage.0
+            && lhs._storage.1 == rhs._storage.1
+            && lhs._storage.2 == rhs._storage.2
+            && lhs._storage.3 == rhs._storage.3
+            && lhs._storage.4 == rhs._storage.4
+            && lhs._storage.5 == rhs._storage.5
+            && lhs._storage.6 == rhs._storage.6
+            && lhs._storage.7 == rhs._storage.7
+            && lhs._storage.8 == rhs._storage.8
+            && lhs._storage.9 == rhs._storage.9
+            && lhs._storage.10 == rhs._storage.10
+            && lhs._storage.11 == rhs._storage.11
+            && lhs._storage.12 == rhs._storage.12
+            && lhs._storage.13 == rhs._storage.13
+            && lhs._storage.14 == rhs._storage.14
+            && lhs._storage.15 == rhs._storage.15
+    }
+}
+
+extension TraceID.Bytes: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_bytes.0)
-        hasher.combine(_bytes.1)
-        hasher.combine(_bytes.2)
-        hasher.combine(_bytes.3)
-        hasher.combine(_bytes.4)
-        hasher.combine(_bytes.5)
-        hasher.combine(_bytes.6)
-        hasher.combine(_bytes.7)
-        hasher.combine(_bytes.8)
-        hasher.combine(_bytes.9)
-        hasher.combine(_bytes.10)
-        hasher.combine(_bytes.11)
-        hasher.combine(_bytes.12)
-        hasher.combine(_bytes.13)
-        hasher.combine(_bytes.14)
-        hasher.combine(_bytes.15)
+        hasher.combine(_storage.0)
+        hasher.combine(_storage.1)
+        hasher.combine(_storage.2)
+        hasher.combine(_storage.3)
+        hasher.combine(_storage.4)
+        hasher.combine(_storage.5)
+        hasher.combine(_storage.6)
+        hasher.combine(_storage.7)
+        hasher.combine(_storage.8)
+        hasher.combine(_storage.9)
+        hasher.combine(_storage.10)
+        hasher.combine(_storage.11)
+        hasher.combine(_storage.12)
+        hasher.combine(_storage.13)
+        hasher.combine(_storage.14)
+        hasher.combine(_storage.15)
     }
 }
 
 extension TraceID: Identifiable {
-    public var id: [UInt8] { bytes }
+    public var id: Bytes { bytes }
+}
+
+extension TraceID.Bytes: CustomStringConvertible {
+    /// A 32 character hex string representation of the bytes.
+    public var description: String {
+        String(decoding: hexBytes, as: UTF8.self)
+    }
+
+    /// A 32 character UTF-8 hex byte array representation of the bytes ID.
+    public var hexBytes: [UInt8] {
+        var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
+        return withUnsafeMutableBytes(of: &asciiBytes) { ptr in
+            ptr[0] = Hex.lookup[Int(_storage.0 >> 4)]
+            ptr[1] = Hex.lookup[Int(_storage.0 & 0x0F)]
+            ptr[2] = Hex.lookup[Int(_storage.1 >> 4)]
+            ptr[3] = Hex.lookup[Int(_storage.1 & 0x0F)]
+            ptr[4] = Hex.lookup[Int(_storage.2 >> 4)]
+            ptr[5] = Hex.lookup[Int(_storage.2 & 0x0F)]
+            ptr[6] = Hex.lookup[Int(_storage.3 >> 4)]
+            ptr[7] = Hex.lookup[Int(_storage.3 & 0x0F)]
+            ptr[8] = Hex.lookup[Int(_storage.4 >> 4)]
+            ptr[9] = Hex.lookup[Int(_storage.4 & 0x0F)]
+            ptr[10] = Hex.lookup[Int(_storage.5 >> 4)]
+            ptr[11] = Hex.lookup[Int(_storage.5 & 0x0F)]
+            ptr[12] = Hex.lookup[Int(_storage.6 >> 4)]
+            ptr[13] = Hex.lookup[Int(_storage.6 & 0x0F)]
+            ptr[14] = Hex.lookup[Int(_storage.7 >> 4)]
+            ptr[15] = Hex.lookup[Int(_storage.7 & 0x0F)]
+            ptr[16] = Hex.lookup[Int(_storage.8 >> 4)]
+            ptr[17] = Hex.lookup[Int(_storage.8 & 0x0F)]
+            ptr[18] = Hex.lookup[Int(_storage.9 >> 4)]
+            ptr[19] = Hex.lookup[Int(_storage.9 & 0x0F)]
+            ptr[20] = Hex.lookup[Int(_storage.10 >> 4)]
+            ptr[21] = Hex.lookup[Int(_storage.10 & 0x0F)]
+            ptr[22] = Hex.lookup[Int(_storage.11 >> 4)]
+            ptr[23] = Hex.lookup[Int(_storage.11 & 0x0F)]
+            ptr[24] = Hex.lookup[Int(_storage.12 >> 4)]
+            ptr[25] = Hex.lookup[Int(_storage.12 & 0x0F)]
+            ptr[26] = Hex.lookup[Int(_storage.13 >> 4)]
+            ptr[27] = Hex.lookup[Int(_storage.13 & 0x0F)]
+            ptr[28] = Hex.lookup[Int(_storage.14 >> 4)]
+            ptr[29] = Hex.lookup[Int(_storage.14 & 0x0F)]
+            ptr[30] = Hex.lookup[Int(_storage.15 >> 4)]
+            ptr[31] = Hex.lookup[Int(_storage.15 & 0x0F)]
+            return Array(ptr)
+        }
+    }
 }
 
 extension TraceID: CustomStringConvertible {
     /// A 32 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: hexBytes, as: UTF8.self)
+        String(decoding: self.bytes.hexBytes, as: UTF8.self)
     }
 
     /// A 32 character UTF-8 hex byte array representation of the span ID.
     public var hexBytes: [UInt8] {
-        var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
-        return withUnsafeMutableBytes(of: &asciiBytes) { ptr in
-            ptr[0] = Hex.lookup[Int(_bytes.0 >> 4)]
-            ptr[1] = Hex.lookup[Int(_bytes.0 & 0x0F)]
-            ptr[2] = Hex.lookup[Int(_bytes.1 >> 4)]
-            ptr[3] = Hex.lookup[Int(_bytes.1 & 0x0F)]
-            ptr[4] = Hex.lookup[Int(_bytes.2 >> 4)]
-            ptr[5] = Hex.lookup[Int(_bytes.2 & 0x0F)]
-            ptr[6] = Hex.lookup[Int(_bytes.3 >> 4)]
-            ptr[7] = Hex.lookup[Int(_bytes.3 & 0x0F)]
-            ptr[8] = Hex.lookup[Int(_bytes.4 >> 4)]
-            ptr[9] = Hex.lookup[Int(_bytes.4 & 0x0F)]
-            ptr[10] = Hex.lookup[Int(_bytes.5 >> 4)]
-            ptr[11] = Hex.lookup[Int(_bytes.5 & 0x0F)]
-            ptr[12] = Hex.lookup[Int(_bytes.6 >> 4)]
-            ptr[13] = Hex.lookup[Int(_bytes.6 & 0x0F)]
-            ptr[14] = Hex.lookup[Int(_bytes.7 >> 4)]
-            ptr[15] = Hex.lookup[Int(_bytes.7 & 0x0F)]
-            ptr[16] = Hex.lookup[Int(_bytes.8 >> 4)]
-            ptr[17] = Hex.lookup[Int(_bytes.8 & 0x0F)]
-            ptr[18] = Hex.lookup[Int(_bytes.9 >> 4)]
-            ptr[19] = Hex.lookup[Int(_bytes.9 & 0x0F)]
-            ptr[20] = Hex.lookup[Int(_bytes.10 >> 4)]
-            ptr[21] = Hex.lookup[Int(_bytes.10 & 0x0F)]
-            ptr[22] = Hex.lookup[Int(_bytes.11 >> 4)]
-            ptr[23] = Hex.lookup[Int(_bytes.11 & 0x0F)]
-            ptr[24] = Hex.lookup[Int(_bytes.12 >> 4)]
-            ptr[25] = Hex.lookup[Int(_bytes.12 & 0x0F)]
-            ptr[26] = Hex.lookup[Int(_bytes.13 >> 4)]
-            ptr[27] = Hex.lookup[Int(_bytes.13 & 0x0F)]
-            ptr[28] = Hex.lookup[Int(_bytes.14 >> 4)]
-            ptr[29] = Hex.lookup[Int(_bytes.14 & 0x0F)]
-            ptr[30] = Hex.lookup[Int(_bytes.15 >> 4)]
-            ptr[31] = Hex.lookup[Int(_bytes.15 & 0x0F)]
-            return Array(ptr)
-        }
+        self.bytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -17,25 +17,20 @@
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
     /// The 16 bytes of the trace ID.
-    public let rawBytes: Bytes
-
-    /// A 16-byte array representation of the trace ID.
-    public var bytes: [UInt8] {
-        withUnsafeBytes(of: rawBytes, Array.init)
-    }
+    public let bytes: Bytes
 
     /// Create a trace ID from 16 bytes.
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: Bytes) {
-        self.rawBytes = bytes
+        self.bytes = bytes
     }
 
     /// Create a trace ID from 16 bytes.
     ///
     /// - Parameter bytes: The 16 bytes making up the trace ID.
     public init(bytes: Bytes.Storage) {
-        self.rawBytes = .init(bytes)
+        self.bytes = .init(bytes)
     }
 
     /// Create a random trace ID using the given random number generator.
@@ -156,7 +151,7 @@ extension TraceID.Bytes: Hashable {
 }
 
 extension TraceID: Identifiable {
-    public var id: Bytes { rawBytes }
+    public var id: Bytes { bytes }
 }
 
 extension TraceID.Bytes: CustomStringConvertible {
@@ -209,11 +204,11 @@ extension TraceID.Bytes: CustomStringConvertible {
 extension TraceID: CustomStringConvertible {
     /// A 32 character hex string representation of the span ID.
     public var description: String {
-        String(decoding: self.rawBytes.hexBytes, as: UTF8.self)
+        String(decoding: self.bytes.hexBytes, as: UTF8.self)
     }
 
     /// A 32 character UTF-8 hex byte array representation of the span ID.
     public var hexBytes: [UInt8] {
-        self.rawBytes.hexBytes
+        self.bytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -51,7 +51,26 @@ public struct TraceID: Sendable {
         var generator = SystemRandomNumberGenerator()
         return random(using: &generator)
     }
+}
 
+extension TraceID: Equatable {}
+
+extension TraceID: Hashable {}
+
+extension TraceID: Identifiable {
+    public var id: Self { self }
+}
+
+extension TraceID: CustomStringConvertible {
+    /// A 32-character hex string representation of the trace ID.
+    public var description: String {
+        "\(bytes)"
+    }
+}
+
+// MARK: - Bytes
+
+extension TraceID {
     /// A 16-byte array.
     public struct Bytes: Collection, Equatable, Hashable, Sendable {
         public static var null: Self { TraceID.Bytes((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) }
@@ -183,25 +202,5 @@ extension TraceID.Bytes: CustomStringConvertible {
             asciiBytes[2 * i + 1] = Hex.lookup[Int(byte & 0x0F)]
         }
         return asciiBytes
-    }
-}
-
-extension TraceID: Equatable {}
-
-extension TraceID: Hashable {}
-
-extension TraceID: Identifiable {
-    public var id: Self { self }
-}
-
-extension TraceID: CustomStringConvertible {
-    /// A 32-character hex string representation of the trace ID.
-    public var description: String {
-        "\(bytes)"
-    }
-
-    /// A 32-character UTF-8 hex byte array representation of the trace ID.
-    public var hexBytes: [UInt8] {
-        bytes.hexBytes
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -178,7 +178,7 @@ extension TraceID.Bytes: CustomStringConvertible {
     /// A 32-character UTF-8 hex byte array representation of the bytes.
     public var hexBytes: [UInt8] {
         var asciiBytes = [UInt8](repeating: 0, count: 32)
-        for i in 0 ..< 16 {
+        for i in startIndex ..< endIndex {
             let byte = self[i]
             asciiBytes[2 * i] = Hex.lookup[Int(byte >> 4)]
             asciiBytes[2 * i + 1] = Hex.lookup[Int(byte & 0x0F)]

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -37,6 +37,7 @@ public struct TraceID: Sendable {
     }
 
     /// Access the bytes of the trace ID in an unsafe manner.
+    @inlinable
     public func withUnsafeBytes<Result>(_ body: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
         try Swift.withUnsafeBytes(of: self.bytes._bytes, body)
     }
@@ -64,7 +65,7 @@ public struct TraceID: Sendable {
 
     /// A 16-byte array.
     public struct Bytes: Sendable {
-        let _bytes: (
+        @usableFromInline let _bytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )

--- a/Tests/W3CTraceContextTests/SpanID+Stubs.swift
+++ b/Tests/W3CTraceContextTests/SpanID+Stubs.swift
@@ -16,5 +16,5 @@ import W3CTraceContext
 
 extension SpanID {
     /// A stubbed `SpanID` with bytes from one to eight.
-    static let oneToEight = SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8))
+    static let oneToEight = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8)))
 }

--- a/Tests/W3CTraceContextTests/SpanIDTests.swift
+++ b/Tests/W3CTraceContextTests/SpanIDTests.swift
@@ -19,12 +19,12 @@ final class SpanIDTests: XCTestCase {
     func test_bytes_returnsEightByteArrayRepresentation() {
         let spanID = SpanID.oneToEight
 
-        XCTAssertEqual(spanID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(Array(spanID.bytes), [1, 2, 3, 4, 5, 6, 7, 8])
     }
 
     func test_equatableConformance() {
-        let spanID1 = SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8))
-        let spanID2 = SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 0))
+        let spanID1 = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8)))
+        let spanID2 = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 0)))
 
         XCTAssertEqual(spanID1, spanID1)
         XCTAssertEqual(spanID2, spanID2)
@@ -38,7 +38,7 @@ final class SpanIDTests: XCTestCase {
     }
 
     func test_description_returnsHexStringRepresentation() {
-        let spanID = SpanID(bytes: (0, 10, 20, 50, 100, 150, 200, 255))
+        let spanID = SpanID(bytes: .init((0, 10, 20, 50, 100, 150, 200, 255)))
 
         XCTAssertEqual("\(spanID)", "000a14326496c8ff")
     }
@@ -47,10 +47,10 @@ final class SpanIDTests: XCTestCase {
         var generator = IncrementingRandomNumberGenerator()
 
         let spanID1 = SpanID.random(using: &generator)
-        XCTAssertEqual(spanID1, SpanID(bytes: (0, 0, 0, 0, 0, 0, 0, 0)))
+        XCTAssertEqual(spanID1, SpanID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0))))
 
         let spanID2 = SpanID.random(using: &generator)
-        XCTAssertEqual(spanID2, SpanID(bytes: (0, 0, 0, 0, 0, 0, 0, 1)))
+        XCTAssertEqual(spanID2, SpanID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 1))))
     }
 
     func test_random_withDefaultNumberGenerator_returnsRandomSpanIDs() {

--- a/Tests/W3CTraceContextTests/SpanIDTests.swift
+++ b/Tests/W3CTraceContextTests/SpanIDTests.swift
@@ -58,4 +58,35 @@ final class SpanIDTests: XCTestCase {
 
         XCTAssertEqual(Set(randomSpanIDs).count, 100)
     }
+
+    // MARK: - Bytes
+
+    func test_spanIDBytes_withUnsafeBytes_invokesClosureWithPointerToBytes() {
+        let bytes = SpanID.Bytes((0, 10, 20, 50, 100, 150, 200, 255))
+
+        let byteArray = bytes.withUnsafeBytes { ptr in
+            Array(ptr)
+        }
+        XCTAssertEqual(byteArray, [0, 10, 20, 50, 100, 150, 200, 255])
+    }
+
+    func test_spanIDBytes_withUnsafeMutableBytes_allowsMutatingBytesViaClosure() {
+        var bytes = SpanID.Bytes((0, 10, 20, 50, 100, 150, 200, 255))
+
+        bytes.withUnsafeMutableBytes { ptr in
+            ptr.storeBytes(of: 42, as: UInt8.self)
+        }
+
+        XCTAssertEqual(Array(bytes), [42, 10, 20, 50, 100, 150, 200, 255])
+    }
+
+    func test_withContiguousStorageIfAvailable_invokesClosureWithPointerToBytes() {
+        let bytes = SpanID.Bytes((0, 10, 20, 50, 100, 150, 200, 255))
+
+        let byteArray = bytes.withContiguousStorageIfAvailable { ptr in
+            Array(ptr)
+        }
+
+        XCTAssertEqual(byteArray, [0, 10, 20, 50, 100, 150, 200, 255])
+    }
 }

--- a/Tests/W3CTraceContextTests/SpanIDTests.swift
+++ b/Tests/W3CTraceContextTests/SpanIDTests.swift
@@ -19,7 +19,7 @@ final class SpanIDTests: XCTestCase {
     func test_bytes_returnsEightByteArrayRepresentation() {
         let spanID = SpanID.oneToEight
 
-        XCTAssertEqual(spanID.bytes, [1, 2, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(spanID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8])
     }
 
     func test_equatableConformance() {

--- a/Tests/W3CTraceContextTests/TraceContextTests.swift
+++ b/Tests/W3CTraceContextTests/TraceContextTests.swift
@@ -22,8 +22,8 @@ final class TraceContextTests: XCTestCase {
         )
 
         XCTAssertEqual(traceContext, TraceContext(
-            traceID: TraceID(bytes: (10, 247, 101, 25, 22, 205, 67, 221, 132, 72, 235, 33, 28, 128, 49, 156)),
-            spanID: SpanID(bytes: (183, 173, 107, 113, 105, 32, 51, 49)),
+            traceID: TraceID(bytes: .init((10, 247, 101, 25, 22, 205, 67, 221, 132, 72, 235, 33, 28, 128, 49, 156))),
+            spanID: SpanID(bytes: .init((183, 173, 107, 113, 105, 32, 51, 49))),
             flags: .sampled,
             state: TraceState()
         ))
@@ -36,8 +36,8 @@ final class TraceContextTests: XCTestCase {
         )
 
         XCTAssertEqual(traceContext, TraceContext(
-            traceID: TraceID(bytes: (10, 247, 101, 25, 22, 205, 67, 221, 132, 72, 235, 33, 28, 128, 49, 156)),
-            spanID: SpanID(bytes: (183, 173, 107, 113, 105, 32, 51, 49)),
+            traceID: TraceID(bytes: .init((10, 247, 101, 25, 22, 205, 67, 221, 132, 72, 235, 33, 28, 128, 49, 156))),
+            spanID: SpanID(bytes: .init((183, 173, 107, 113, 105, 32, 51, 49))),
             flags: .sampled,
             state: TraceState([
                 (.simple("foo"), "bar"),

--- a/Tests/W3CTraceContextTests/TraceID+Stubs.swift
+++ b/Tests/W3CTraceContextTests/TraceID+Stubs.swift
@@ -16,5 +16,5 @@ import W3CTraceContext
 
 extension TraceID {
     /// A stubbed `TraceID` with bytes from one to sixteen.
-    static let oneToSixteen = TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+    static let oneToSixteen = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)))
 }

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -19,12 +19,13 @@ final class TraceIDTests: XCTestCase {
     func test_bytes_returnsSixteenByteArrayRepresentation() {
         let traceID = TraceID.oneToSixteen
 
-        XCTAssertEqual(traceID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        let array = Array(traceID.bytes)
+        XCTAssertEqual(array, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
     func test_equatableConformance() {
-        let traceID1 = TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
-        let traceID2 = TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0))
+        let traceID1 = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)))
+        let traceID2 = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0)))
 
         XCTAssertEqual(traceID1, traceID1)
         XCTAssertEqual(traceID2, traceID2)
@@ -38,7 +39,7 @@ final class TraceIDTests: XCTestCase {
     }
 
     func test_description_returnsHexStringRepresentation() {
-        let traceID = TraceID(bytes: (0, 10, 20, 30, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220, 240, 255))
+        let traceID = TraceID(bytes: .init((0, 10, 20, 30, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220, 240, 255)))
 
         XCTAssertEqual("\(traceID)", "000a141e283c5064788ca0b4c8dcf0ff")
     }
@@ -47,10 +48,10 @@ final class TraceIDTests: XCTestCase {
         var generator = IncrementingRandomNumberGenerator()
 
         let traceID1 = TraceID.random(using: &generator)
-        XCTAssertEqual(traceID1, TraceID(bytes: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)))
+        XCTAssertEqual(traceID1, TraceID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))))
 
         let traceID2 = TraceID.random(using: &generator)
-        XCTAssertEqual(traceID2, TraceID(bytes: (0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3)))
+        XCTAssertEqual(traceID2, TraceID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3))))
     }
 
     func test_random_withDefaultNumberGenerator_returnsRandomSpanIDs() {

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -19,7 +19,7 @@ final class TraceIDTests: XCTestCase {
     func test_bytes_returnsSixteenByteArrayRepresentation() {
         let traceID = TraceID.oneToSixteen
 
-        XCTAssertEqual(traceID.bytes, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        XCTAssertEqual(traceID.bytes.array, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
     func test_equatableConformance() {

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -59,4 +59,35 @@ final class TraceIDTests: XCTestCase {
 
         XCTAssertEqual(Set(randomTraceIDs).count, 100)
     }
+
+    // MARK: - Bytes
+
+    func test_traceIDBytes_withUnsafeBytes_invokesClosureWithPointerToBytes() {
+        let bytes = TraceID.Bytes((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+
+        let byteArray = bytes.withUnsafeBytes { ptr in
+            Array(ptr)
+        }
+        XCTAssertEqual(byteArray, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    }
+
+    func test_traceIDBytes_withUnsafeMutableBytes_allowsMutatingBytesViaClosure() {
+        var bytes = TraceID.Bytes((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+
+        bytes.withUnsafeMutableBytes { ptr in
+            ptr.storeBytes(of: 42, as: UInt8.self)
+        }
+
+        XCTAssertEqual(Array(bytes), [42, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    }
+
+    func test_withContiguousStorageIfAvailable_invokesClosureWithPointerToBytes() {
+        let bytes = TraceID.Bytes((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+
+        let byteArray = bytes.withContiguousStorageIfAvailable { ptr in
+            Array(ptr)
+        }
+
+        XCTAssertEqual(byteArray, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    }
 }

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -19,7 +19,7 @@ final class TraceIDTests: XCTestCase {
     func test_bytes_returnsSixteenByteArrayRepresentation() {
         let traceID = TraceID.oneToSixteen
 
-        XCTAssertEqual(traceID.bytes.array, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        XCTAssertEqual(traceID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
     func test_equatableConformance() {


### PR DESCRIPTION
I would suggest to expose the "fixed-width 16 byte array" directly on `TraceID` and `SpanID` for performance reasons. Otherwise, clients will too easily go through the `var bytes: [UInt8]` property which causes an allocation on every access. Of course this is a breaking change of the API, but the performance win seems worthwhile.

For example, while implementing a `TraceIdRatioBasedSampler` [here](https://github.com/slashmo/swift-otel/pull/131) I had to access the last 8 bytes of the `TraceID` to determine if the sample should be dropped or recorded. When going through the `var bytes: [UInt8]` this causes an allocation on each check. If I use the approach presented here, there are 0 allocations.

I also changed the conformance to `Identifiable` to use the type itself as the "id".

With [`Benchmark`](https://github.com/ordo-one/package-benchmark) I was able to measure the difference:

### Benchmark

```swift
let benchmarks = {
    Benchmark("OTelTraceIdRatioBasedSampler") { benchmark in

        let sampler = OTelTraceIdRatioBasedSampler(ratio: 0.5)
        for _ in benchmark.scaledIterations {
            _ = sampler.samplingResult(
                operationName: "some-op",
                kind: .internal,
                traceID: .random(),
                attributes: [:],
                links: [],
                parentContext: .topLevel)
        }

    }
}
```


### With `[UInt8]`

```
=====================================
OTelTraceIdRatioBasedSamplerBenchmark
=====================================

OTelTraceIdRatioBasedSampler
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Instructions *                │    1317 │    6647 │    6647 │    6647 │    6647 │    9623 │   15592 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total) *              │       1 │       1 │       1 │       1 │       1 │       1 │       1 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (K)    │    9126 │    9511 │    9511 │    9527 │    9552 │    9552 │    9552 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)        │     631 │     600 │     586 │     585 │     522 │     304 │      69 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ns) *       │    3874 │    4167 │    4211 │    4251 │    4583 │    7211 │   26916 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ns) *      │    1584 │    1667 │    1708 │    1709 │    1917 │    3293 │   14500 │   10000 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```

### With `unsafeBytes`

```
=====================================
OTelTraceIdRatioBasedSamplerBenchmark
=====================================

OTelTraceIdRatioBasedSampler
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Instructions *                │    2275 │    2279 │    2279 │    2279 │    2279 │    5255 │   10018 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total) *              │       0 │       0 │       0 │       0 │       0 │       0 │       0 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (K)    │    9159 │    9527 │    9527 │    9544 │    9568 │    9568 │    9568 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)        │    1333 │    1201 │    1201 │    1199 │    1091 │     586 │      58 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ns) *       │    2917 │    3209 │    3209 │    3251 │    3541 │    6127 │   37125 │   10000 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ns) *      │     750 │     833 │     833 │     834 │     917 │    1667 │   17250 │   10000 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

The throughput roughly doubles, which I would consider a great win for a tracing library which usually is executed in hot code paths.