### PR TITLE
Make {Trace|Span}ID conform to `Collection`

### DIFF
--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -19,9 +19,9 @@ public struct SpanID: Sendable {
     @usableFromInline
     let _bytes: Bytes
 
-    /// Calls the given closure with a pointer to the trace ID's underlying bytes.
+    /// Calls the given closure with a pointer to the span ID's underlying bytes.
     ///
-    /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the trace ID's underlying bytes.
+    /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the span ID's underlying bytes.
     @inlinable
     public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
         try Swift.withUnsafeBytes(of: _bytes, body)

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -18,9 +18,8 @@
 public struct SpanID: Sendable {
     private let _bytes: Bytes
 
-    /// An 8-byte array representation of the span ID.
-    public var bytes: [UInt8] {
-        withUnsafeBytes(of: _bytes, Array.init)
+    public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
+        try Swift.withUnsafeBytes(of: self._bytes, body)
     }
 
     /// Create a span ID from 8 bytes.
@@ -54,6 +53,32 @@ public struct SpanID: Sendable {
     public typealias Bytes = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 }
 
+extension SpanID: Collection {
+    public typealias Element = UInt8
+
+    public subscript(position: Int) -> UInt8 {
+        switch position {
+            case 0: return _bytes.0
+            case 1: return _bytes.1
+            case 2: return _bytes.2
+            case 3: return _bytes.3
+            case 4: return _bytes.4
+            case 5: return _bytes.5
+            case 6: return _bytes.6
+            case 7: return _bytes.7
+            default: fatalError("Index out of bounds")
+        }
+    }
+
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { 8 }
+
+    public func index(after i: Int) -> Int {
+        precondition(i < self.endIndex, "Can't advance beyond endIndex")
+        return i + 1
+    }
+}
+
 extension SpanID: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs._bytes.0 == rhs._bytes.0
@@ -81,7 +106,7 @@ extension SpanID: Hashable {
 }
 
 extension SpanID: Identifiable {
-    public var id: [UInt8] { bytes }
+    public var id: Self { self }
 }
 
 extension SpanID: CustomStringConvertible {

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -24,7 +24,7 @@ public struct SpanID: Sendable {
     /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the trace ID's underlying bytes.
     @inlinable
     public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
-        try Swift.withUnsafeBytes(of: self._bytes, body)
+        try Swift.withUnsafeBytes(of: _bytes, body)
     }
 
     /// Create a span ID from 8 bytes.
@@ -63,15 +63,15 @@ extension SpanID: Collection {
 
     public subscript(position: Int) -> UInt8 {
         switch position {
-            case 0: return _bytes.0
-            case 1: return _bytes.1
-            case 2: return _bytes.2
-            case 3: return _bytes.3
-            case 4: return _bytes.4
-            case 5: return _bytes.5
-            case 6: return _bytes.6
-            case 7: return _bytes.7
-            default: fatalError("Index out of bounds")
+        case 0: _bytes.0
+        case 1: _bytes.1
+        case 2: _bytes.2
+        case 3: _bytes.3
+        case 4: _bytes.4
+        case 5: _bytes.5
+        case 6: _bytes.6
+        case 7: _bytes.7
+        default: fatalError("Index out of bounds")
         }
     }
 
@@ -79,7 +79,7 @@ extension SpanID: Collection {
     public var endIndex: Int { 8 }
 
     public func index(after i: Int) -> Int {
-        precondition(i < self.endIndex, "Can't advance beyond endIndex")
+        precondition(i < endIndex, "Can't advance beyond endIndex")
         return i + 1
     }
 }

--- a/Sources/W3CTraceContext/SpanID.swift
+++ b/Sources/W3CTraceContext/SpanID.swift
@@ -16,8 +16,13 @@
 ///
 /// [W3C TraceContext: parent-id](https://www.w3.org/TR/trace-context-1/#parent-id)
 public struct SpanID: Sendable {
-    private let _bytes: Bytes
+    @usableFromInline
+    let _bytes: Bytes
 
+    /// Calls the given closure with a pointer to the trace ID's underlying bytes.
+    ///
+    /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the trace ID's underlying bytes.
+    @inlinable
     public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
         try Swift.withUnsafeBytes(of: self._bytes, body)
     }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -17,14 +17,14 @@
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
     @usableFromInline
-    internal let _bytes: Bytes
+    let _bytes: Bytes
 
     /// Calls the given closure with a pointer to the trace ID's underlying bytes.
     ///
     /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the trace ID's underlying bytes.
     @inlinable
     public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
-        try Swift.withUnsafeBytes(of: self._bytes, body)
+        try Swift.withUnsafeBytes(of: _bytes, body)
     }
 
     /// Create a trace ID from 16 bytes.
@@ -67,23 +67,23 @@ extension TraceID: Collection {
 
     public subscript(position: Int) -> UInt8 {
         switch position {
-            case  0: return self._bytes.0
-            case  1: return self._bytes.1
-            case  2: return self._bytes.2
-            case  3: return self._bytes.3
-            case  4: return self._bytes.4
-            case  5: return self._bytes.5
-            case  6: return self._bytes.6
-            case  7: return self._bytes.7
-            case  8: return self._bytes.8
-            case  9: return self._bytes.9
-            case 10: return self._bytes.10
-            case 11: return self._bytes.11
-            case 12: return self._bytes.12
-            case 13: return self._bytes.13
-            case 14: return self._bytes.14
-            case 15: return self._bytes.15
-            default: fatalError("Index out of bounds")
+        case 0: _bytes.0
+        case 1: _bytes.1
+        case 2: _bytes.2
+        case 3: _bytes.3
+        case 4: _bytes.4
+        case 5: _bytes.5
+        case 6: _bytes.6
+        case 7: _bytes.7
+        case 8: _bytes.8
+        case 9: _bytes.9
+        case 10: _bytes.10
+        case 11: _bytes.11
+        case 12: _bytes.12
+        case 13: _bytes.13
+        case 14: _bytes.14
+        case 15: _bytes.15
+        default: fatalError("Index out of bounds")
         }
     }
 
@@ -91,7 +91,7 @@ extension TraceID: Collection {
     public var endIndex: Int { 16 }
 
     public func index(after i: Int) -> Int {
-        precondition(i < self.endIndex, "Can't advance beyond endIndex")
+        precondition(i < endIndex, "Can't advance beyond endIndex")
         return i + 1
     }
 }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -18,9 +18,8 @@
 public struct TraceID: Sendable {
     private let _bytes: Bytes
 
-    /// A 16-byte array representation of the span ID.
-    public var bytes: [UInt8] {
-        withUnsafeBytes(of: _bytes, Array.init)
+    public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
+        try Swift.withUnsafeBytes(of: self._bytes, body)
     }
 
     /// Create a trace ID from 16 bytes.
@@ -56,6 +55,40 @@ public struct TraceID: Sendable {
         UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
         UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
     )
+}
+
+extension TraceID: Collection {
+    public typealias Element = UInt8
+
+    public subscript(position: Int) -> UInt8 {
+        switch position {
+            case  0: return self._bytes.0
+            case  1: return self._bytes.1
+            case  2: return self._bytes.2
+            case  3: return self._bytes.3
+            case  4: return self._bytes.4
+            case  5: return self._bytes.5
+            case  6: return self._bytes.6
+            case  7: return self._bytes.7
+            case  8: return self._bytes.8
+            case  9: return self._bytes.9
+            case 10: return self._bytes.10
+            case 11: return self._bytes.11
+            case 12: return self._bytes.12
+            case 13: return self._bytes.13
+            case 14: return self._bytes.14
+            case 15: return self._bytes.15
+            default: fatalError("Index out of bounds")
+        }
+    }
+
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { 16 }
+
+    public func index(after i: Int) -> Int {
+        precondition(i < self.endIndex, "Can't advance beyond endIndex")
+        return i + 1
+    }
 }
 
 extension TraceID: Equatable {
@@ -101,7 +134,7 @@ extension TraceID: Hashable {
 }
 
 extension TraceID: Identifiable {
-    public var id: [UInt8] { bytes }
+    public var id: Self { self }
 }
 
 extension TraceID: CustomStringConvertible {

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -16,8 +16,13 @@
 ///
 /// [W3C TraceContext: trace-id](https://www.w3.org/TR/trace-context-1/#trace-id)
 public struct TraceID: Sendable {
-    private let _bytes: Bytes
+    @usableFromInline
+    internal let _bytes: Bytes
 
+    /// Calls the given closure with a pointer to the trace ID's underlying bytes.
+    ///
+    /// - Parameter body: A closure receiving an `UnsafeRawBufferPointer` to the trace ID's underlying bytes.
+    @inlinable
     public func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
         try Swift.withUnsafeBytes(of: self._bytes, body)
     }

--- a/Sources/W3CTraceContext/TraceID.swift
+++ b/Sources/W3CTraceContext/TraceID.swift
@@ -29,7 +29,7 @@ public struct TraceID: Sendable {
 
     /// Create a trace ID from 16 bytes.
     ///
-    /// - Parameter bytes: The eight bytes making up the span ID.
+    /// - Parameter bytes: The eight bytes making up the trace ID.
     public init(bytes: Bytes) {
         _bytes = bytes
     }
@@ -143,12 +143,12 @@ extension TraceID: Identifiable {
 }
 
 extension TraceID: CustomStringConvertible {
-    /// A 32 character hex string representation of the span ID.
+    /// A 32 character hex string representation of the trace ID.
     public var description: String {
         String(decoding: hexBytes, as: UTF8.self)
     }
 
-    /// A 32 character UTF-8 hex byte array representation of the span ID.
+    /// A 32 character UTF-8 hex byte array representation of the trace ID.
     public var hexBytes: [UInt8] {
         var asciiBytes: (UInt64, UInt64, UInt64, UInt64) = (0, 0, 0, 0)
         return withUnsafeMutableBytes(of: &asciiBytes) { ptr in

--- a/Tests/W3CTraceContextTests/SpanIDTests.swift
+++ b/Tests/W3CTraceContextTests/SpanIDTests.swift
@@ -19,7 +19,7 @@ final class SpanIDTests: XCTestCase {
     func test_bytes_returnsEightByteArrayRepresentation() {
         let spanID = SpanID.oneToEight
 
-        XCTAssertEqual(spanID.bytes, [1, 2, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(Array(spanID), [1, 2, 3, 4, 5, 6, 7, 8])
     }
 
     func test_equatableConformance() {

--- a/Tests/W3CTraceContextTests/SpanIDTests.swift
+++ b/Tests/W3CTraceContextTests/SpanIDTests.swift
@@ -20,6 +20,7 @@ final class SpanIDTests: XCTestCase {
         let spanID = SpanID.oneToEight
 
         XCTAssertEqual(Array(spanID), [1, 2, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(spanID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8])
     }
 
     func test_equatableConformance() {

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -19,7 +19,7 @@ final class TraceIDTests: XCTestCase {
     func test_bytes_returnsSixteenByteArrayRepresentation() {
         let traceID = TraceID.oneToSixteen
 
-        XCTAssertEqual(traceID.bytes, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        XCTAssertEqual(Array(traceID), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
     func test_equatableConformance() {

--- a/Tests/W3CTraceContextTests/TraceIDTests.swift
+++ b/Tests/W3CTraceContextTests/TraceIDTests.swift
@@ -20,6 +20,7 @@ final class TraceIDTests: XCTestCase {
         let traceID = TraceID.oneToSixteen
 
         XCTAssertEqual(Array(traceID), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        XCTAssertEqual(traceID.withUnsafeBytes(Array.init), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
     func test_equatableConformance() {


### PR DESCRIPTION
And remove `bytes`.

Alternative to #18 

Avoids a bunch of code and should yield the same results and be even easier to use. Still need to run the benchmark.