### PR TITLE
[CI] Add Swift 5.10 to unit test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: [5.9, latest]
+        swift: ["5.9", "5.10", "latest"]
 
     steps:
       - name: Install Swift


### PR DESCRIPTION
Now that `latest` refers to Swift 6, we should include Swift 5.10 explicitly in the unit test matrix to ensure all supported Swift versions are tested against.